### PR TITLE
Fix comment about GC flag

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -34,7 +34,7 @@
 
 ; The assembler `wat2wasm` from the "official" wabt tools
 ; does not support the GC proposal (which includes i31).
-; The tool as a flag `--enable-gc` but it has no effect on the assembler.
+; The tool has a flag `--enable-gc` but it has no effect on the assembler.
 ; The issue is that the options are shared between a set of tools,
 ; and some of the other tools support the GC proposal.
 


### PR DESCRIPTION
## Summary
- fix typo in assembler notes about `--enable-gc`

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6888d504f69c8322a08d4f9f1b2e356c