### PR TITLE
Add js_print_fasl primitive import for FASL logging

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -155,7 +155,12 @@ var imports = {
     'primitives': {
       'console_log': ((x)   => console.log(x)),
       'add':         ((x,y) => x+y),
-      'js_output':   ((x)   => output_string.push(x))        
+      'js_output':   ((x)   => output_string.push(x)),
+      'js_print_fasl': ((start, len) => {
+        const bytes = new Uint8Array(memory.buffer).slice(start, start + len);
+        const [v] = fasl_to_js_value(bytes);
+        console.log(v);
+      })
     }
 };
 

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3853,6 +3853,9 @@
          (func $js_output
                (import "primitives" "js_output")
                (param i32))
+         (func $js_print_fasl
+               (import "primitives" "js_print_fasl")
+               (param i32) (param i32))
 
          ;; Exceptions
          (func $raise-wrong-number-of-values-received (unreachable))


### PR DESCRIPTION
## Summary
- Add `js_print_fasl` primitive to runtime imports to decode and log FASL data
- Import new `js_print_fasl` function in compiler for WebAssembly modules

## Testing
- `raco make assembler.rkt compiler.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688dfc6849d8832291c929390a69f71d