### PR TITLE
Add js_log primitive for JavaScript logging

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -442,6 +442,7 @@
   variable-reference-from-unsafe?
   variable-reference-constant?
 
+  js-log
 
   ;; 17. Unsafe Operations
   unsafe-fx+
@@ -10684,6 +10685,18 @@
                             (br $copy)))
                ;; 5. Return total bytes copied
                (local.get $len))
+
+         (func $js_log
+               (param $v (ref eq))
+               (result (ref eq))
+
+               (local $len i32)
+
+               (global.set $result-bytes
+                           (call $s-exp->fasl (local.get $v) (global.get $false)))
+               (local.set $len (call $copy_bytes_to_memory (i32.const 0)))
+               (call $js_print_fasl (i32.const 0) (local.get $len))
+               (global.get $void))
 
          ;;;
          ;;; STRUCTURES

--- a/priminfo.rkt
+++ b/priminfo.rkt
@@ -49,6 +49,7 @@
     alt-reverse         ; in expansion of for/list
 
     raise-unbound-variable-reference ; used for unbound variables outside modules
+    js-log
     ))
 
 (define (primitive->description sym-or-primitive)

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -130,8 +130,12 @@
 
  s-exp->fasl
  fasl->s-exp
+ js_log
 
 )
+
+(define (js_log v)
+  (displayln v))
 
          
          


### PR DESCRIPTION
## Summary
- add `js_log` primitive to convert values to FASL, copy into linear memory, and delegate output to host `js_print_fasl`
- register `js_log` across compiler metadata and provide a Racket stub implementation
- expose host `js_print_fasl` in assembler imports

## Testing
- `raco test -x .` *(fails: `raco` not found)*
- `apt-get update` *(fails: 403 Forbidden for all repositories)*

------
https://chatgpt.com/codex/tasks/task_e_688dff3a371c832296287025d9f17913