### PR TITLE
Fix signed i31 conversion in JS runtime

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -103,8 +103,10 @@ function fasl_to_js_value(arr, i = 0) {
   }
 
   switch(tag) {
-    case @|fasl-fixnum|:
-      return [u32(), i];
+    case @|fasl-fixnum|: {
+      const raw = u32();
+      return [(raw << 1) >> 1, i];
+    }
     case @|fasl-character|:
       return [String.fromCodePoint(u32()), i];
     case @|fasl-symbol|:


### PR DESCRIPTION
## Summary
- sign-extend i31 fixnums when decoding FASL values in the JS host runtime

## Testing
- `node - <<'NODE'
function read_u32(arr,i){return ((arr[i]<<24)|(arr[i+1]<<16)|(arr[i+2]<<8)|arr[i+3])>>>0;}
function fasl_to_js_value(arr,i=0){const tag=arr[i++];function u32(){const v=read_u32(arr,i);i+=4;return v;}switch(tag){case 8:{const n=u32();const vec=new Array(n);for(let j=0;j<n;j++){[vec[j],i]=fasl_to_js_value(arr,i);}return [vec,i];}case 0:{const raw=u32();return[(raw<<1)>>1,i];}default:return[null,i];}}
const bytes=Uint8Array.from([8,0,0,0,2,0,0x7F,0xFF,0xFF,0xFF,0,0x7F,0xFF,0xFF,0xD6]);
const [v]=fasl_to_js_value(bytes);
console.log(v);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68927a030ff0832293fbba9ccfcb295d