### PR TITLE
Fix sign extension for 30-bit fixnums in JS runtime

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -105,7 +105,8 @@ function fasl_to_js_value(arr, i = 0) {
   switch(tag) {
     case @|fasl-fixnum|: {
       const raw = u32();
-      return [(raw << 1) >> 1, i];
+      // Sign-extend the 30-bit payload so negative fixnums decode correctly.
+      return [(raw << 2) >> 2, i];
     }
     case @|fasl-character|:
       return [String.fromCodePoint(u32()), i];


### PR DESCRIPTION
## Summary
- Correctly sign-extend 30-bit fixnum payload when decoding FASL data in the JavaScript runtime.

## Testing
- `node - <<'NODE' ... NODE` (decodes FASL vector with negative numbers)
- `raco test assembler.rkt compiler.rkt` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors when reaching repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68927dc5213c8322af08b247fdf87f7d