### PR TITLE
Split document and element DOM bindings

### DIFF
--- a/dom.ffi
+++ b/dom.ffi
@@ -29,14 +29,7 @@
   #:name   "create-text-node"
   (-> (string) (extern)))
 
-(define-foreign js-append-child!
-  #:module "document" ; should be put in "element"
-  #:name   "append-child!"
-  ;; Parameters: two external references which may be null
-  ;; Result: an external reference which may be null
-  (-> (extern extern) (extern)))
-
-(define-foreign js-make-element
+(define-foreign js-create-element
   #:module "document"
   #:name   "create-element"
   (-> (string) (extern)))
@@ -50,7 +43,14 @@
 ;     https://developer.mozilla.org/en-US/docs/Web/API/Element 
 ;                                                              
 (define-foreign js-set-attribute!
-  #:module "document"
+  #:module "element"
   #:name   "set-attribute!"
   (-> (extern string string) ()))
+
+(define-foreign js-append-child!
+  #:module "element"
+  #:name   "append-child!"
+  ;; Parameters: two external references which may be null
+  ;; Result: an external reference which may be null
+  (-> (extern extern) (extern)))
 

--- a/runtime.js
+++ b/runtime.js
@@ -377,15 +377,19 @@ var imports = {
         // Browser
         'body':             (()                  => document.body),
         'create-text-node': ((fasl_start)        => document.createTextNode(from_fasl(fasl_start))),
-        'append-child!':    ((parent, child)     => parent.appendChild(child)),
         'create-element':   ((local_name)        => document.createElement(from_fasl(local_name))),
-        'set-attribute!':   ((elem, name, value) => elem.setAttribute(from_fasl(name), from_fasl(value))),
     }
     : { // Node
         'body'()             { throw new Error('DOM not available in this environment'); },
         'create-text-node'() { throw new Error('DOM not available in this environment'); },
-        'append-child!'()    { throw new Error('DOM not available in this environment'); },
         'create-element'()   { throw new Error('DOM not available in this environment'); },
+    },
+    element: hasDOM ? {
+        'append-child!':    ((parent, child)     => parent.appendChild(child)),
+        'set-attribute!':   ((elem, name, value) => elem.setAttribute(from_fasl(name), from_fasl(value))),
+    }
+    : { // Node
+        'append-child!'()    { throw new Error('DOM not available in this environment'); },
         'set-attribute!'()   { throw new Error('DOM not available in this environment'); },
     }
 };

--- a/test/html-example.rkt
+++ b/test/html-example.rkt
@@ -23,13 +23,13 @@
     ; a tree 
     [(list tag (list '@ attrs ...) children ...)
      ;; Create a new element with the given tag.
-     (define elem (js-make-element (symbol->string tag)))
+     (define elem (js-create-element (symbol->string tag)))
      (set-elem-attributes elem attrs)
      (add-children elem children)
      elem]
     [(list tag children ...)
      ;; Create a new element with the given tag.
-     (define elem (js-make-element (symbol->string tag)))
+     (define elem (js-create-element (symbol->string tag)))
      (add-children elem children)
      elem]))
      


### PR DESCRIPTION
## Summary
- Move `append-child!` and `set-attribute!` to a dedicated `element` import
- Add `js-create-element` binding and update example to use it
- Separate `document` and `element` modules in the runtime

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `raco test test/html-example.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3be14dee08322a988ba2434ac7e75