### PR TITLE
Add scrolling text demo

### DIFF
--- a/test/scroll.rkt
+++ b/test/scroll.rkt
@@ -1,0 +1,53 @@
+(define sxml
+  '(section
+    (h1 (@ (style "color: blue")) "Hello #racket !!!!")
+    (p "Test: calling JavaScript from WebRacket")
+    (small "Made with WebRacket")))
+
+(define (add-children elem children)
+  (for ([child (in-list children)])
+    (js-append-child! elem (sxml->dom child))))
+
+(define (set-elem-attributes elem attrs)
+  (for ([attr (in-list attrs)])
+    (match attr
+      [(list name value)
+       (js-set-attribute! elem (symbol->string name) value)])))
+
+(define (sxml->dom exp)
+  (match exp
+    [(? string? s)
+     (js-create-text-node exp)]
+    [(list tag (list '@ attrs ...) children ...)
+     ;; Create a new element with the given tag.
+     (define elem (js-create-element (symbol->string tag)))
+     (set-elem-attributes elem attrs)
+     (add-children elem children)
+     elem]
+    [(list tag children ...)
+     ;; Create a new element with the given tag.
+     (define elem (js-create-element (symbol->string tag)))
+     (add-children elem children)
+     elem]))
+
+(js-append-child! (js-document-body) (sxml->dom sxml))
+
+(js-log (vector "hello"))
+
+;; Clear previous content and set black background
+(js-eval "document.body.innerHTML='';")
+(js-set-attribute! (js-document-body) "style"
+                   "background-color: black; margin:0; overflow:hidden;")
+
+;; Add CSS for scrolling text
+(define style-element (js-create-element "style"))
+(js-append-child! style-element
+  (js-create-text-node
+   "@keyframes scroll-left {0% { left: 100%; } 100% { left: -100%; }}\n#scroll-text { position: fixed; top: 50%; left: 100%; transform: translateY(-50%); white-space: nowrap; color: white; font-size: 24px; animation: scroll-left 10s linear infinite; }"))
+(js-append-child! (js-document-body) style-element)
+
+;; Create scrolling text element
+(define scroll-div (js-create-element "div"))
+(js-set-attribute! scroll-div "id" "scroll-text")
+(js-append-child! scroll-div (js-create-text-node "Welcome to WebRacket!"))
+(js-append-child! (js-document-body) scroll-div)


### PR DESCRIPTION
## Summary
- add scroll.rkt example that includes html-example logic and demonstrates centered scrolling text on black background

## Testing
- `racket test/test-basics.rkt` *(fails: command not found: racket)*
- `racket test/scroll.rkt` *(fails: command not found: racket)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1ca379c8322843a41ca8fea66eb