### PR TITLE
Use unicode checkboxes in completion example

### DIFF
--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -1194,10 +1194,10 @@
 
 (define (primitive-li sym)
   (define checked? (memq sym implemented-primitives))
+  (define box (if checked? "☑" "☐"))
   `(li
      (label
-       (input (@ (type "checkbox") (disabled "")
-                 ,@(if checked? '((checked "")) '())))
+       (span ,box)
        (a (@ (href ,(primitive-url sym))) ,(symbol->string sym)))))
 
 (define (section->sxml section)


### PR DESCRIPTION
## Summary
- Replace HTML checkbox inputs with unicode symbols in the completion example

## Testing
- `raco test test/completion.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d0470c10832281644949ce188dce