### PR TITLE
Add basic format using string-replace

### DIFF
--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -35,6 +35,13 @@
            (string-append acc (substring str start str-len))))]))
 
 
+(define (format fmt . args)
+  (let loop ([s fmt] [args args])
+    (if (null? args)
+        s
+        (loop (string-replace s "~a" (car args)) (cdr args)))))
+
+
 (define (add-children elem children)
   ; (js-log 'add-children)
   (for ([child (in-list children)])


### PR DESCRIPTION
## Summary
- add a simple `format` helper that replaces `~a` placeholders using `string-replace`

## Testing
- `raco test test/completion.rkt` *(fails: raco: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a64c5216bc832285e5603c49f42d6b