### PR TITLE
Add keyword->immutable-string primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -506,6 +506,7 @@
 
   keyword?
   keyword->string
+  keyword->immutable-string
   string->keyword
   keyword<?
 

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -46,13 +46,13 @@
  ;; 4.7.1
  symbol->immutable-string
 
- ;; 4.9 Keywords
+;; 4.9 Keywords
 
  keyword?
  keyword->string
  keyword<?
  ; 4.9.1 Additional Keyword Functions
- ; symbol->immutable-string  ; from racket/keyword
+ keyword->immutable-string
  
  
  ;; 4.10 Pairs and Lists

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -5816,11 +5816,42 @@
          (func $keyword->string/checked
                (param $kw       (ref $Keyword))
                (result          (ref $String))
-               
+
                (local $name     (ref $String))
                (local.set $name (struct.get $Keyword $str (local.get $kw)))
-               
+
                (ref.cast (ref $String) (call $string-copy (local.get $name))))
+
+         (func $keyword->immutable-string
+               (param $kw (ref eq))
+               (result    (ref $String))
+               ;; Type check: must be a keyword
+               (if (i32.eqz (ref.test (ref $Keyword) (local.get $kw)))
+                   (then (call $raise-argument-error:keyword-expected (local.get $kw))
+                         (unreachable)))
+               ;; Cast and delegate
+               (call $keyword->immutable-string/checked (ref.cast (ref $Keyword) (local.get $kw))))
+
+         (func $keyword->immutable-string/checked
+               (param $kw (ref $Keyword))
+               (result    (ref $String))
+
+               (local $name (ref $String))
+               (local $src  (ref $I32Array))
+               (local $dst  (ref $I32Array))
+               (local $len  i32)
+
+               (local.set $name (struct.get $Keyword $str (local.get $kw)))
+
+               (if (result (ref $String))
+                   (i32.eq (struct.get $String $immutable (local.get $name)) (i32.const 1))
+                   (then (local.get $name))
+                   (else
+                    (local.set $src (struct.get $String $codepoints (local.get $name)))
+                    (local.set $len (array.len (local.get $src)))
+                    (local.set $dst (call $i32array-copy
+                                              (local.get $src) (i32.const 0) (local.get $len)))
+                    (struct.new $String (i32.const 0) (i32.const 1) (local.get $dst)))))
 
          (func $raise-keyword-expected (unreachable))
          

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -307,7 +307,7 @@
             #;(equal? (eq? (keyword->string '#:apple)
                          (keyword->string '#:apple))
                     #f)
-            #;(equal? (keyword->immutable-string '#:apple) "apple")            ; todo - implement keyword->immutable-string
+            (equal? (keyword->immutable-string '#:apple) "apple")
             #;(equal? (immutable? (keyword->immutable-string '#:apple)) #t)
 
             #;(equal? (procedure-arity keyword?) 1))) 


### PR DESCRIPTION
## Summary
- Implement `keyword->immutable-string` to access a keyword's immutable name
- Export the primitive through the compiler and runtime
- Update keyword examples to use the new primitive

------
https://chatgpt.com/codex/tasks/task_e_68a725f642a08322806de93f2462c1ea