### PR TITLE
Add bytes->immutable-bytes primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -465,7 +465,7 @@
   vector->list
   
   bytes?  make-bytes  bytes-ref  bytes-set!  bytes-length  subbytes bytes-copy!
-  bytes-copy bytes-fill! bytes-append bytes->list list->bytes bytes=?
+  bytes-copy bytes-fill! bytes-append bytes->immutable-bytes bytes->list list->bytes bytes=?
 
   
   string? string=? string<?

--- a/docs/bytes.scrbl
+++ b/docs/bytes.scrbl
@@ -62,7 +62,9 @@ positions are initialized with the given @racket[b]s.
 
 @examples[
 (bytes->immutable-bytes (bytes 65 65 65))
-(define b (bytes->immutable-bytes (make-bytes 5 65)))
+(define m (make-bytes 5 65))
+(eq? (bytes->immutable-bytes m) m)
+(define b (bytes->immutable-bytes m))
 (bytes->immutable-bytes b)
 (eq? (bytes->immutable-bytes b) b)
 ]}

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -119,6 +119,14 @@
             (equal? (string-append "A" "B") "AB")
             (equal? (string-append "A" "B" "C") "ABC")))
 
+ (list "bytes->immutable-bytes"
+       (let* ([m (bytes 65 66 67)]
+              [i (bytes->immutable-bytes m)]
+              [i2 (bytes->immutable-bytes i)])
+         (and (equal? i m)
+              (not (eq? i m))
+              (eq? i2 i))))
+
 #; (list "string-replace"
        (and (equal? (string-replace "foo bar baz" "bar" "blah") "foo blah baz")
             (equal? (string-replace "foo foo" "foo" "bar" #f) "bar foo")))


### PR DESCRIPTION
## Summary
- add `bytes->immutable-bytes` to convert mutable byte strings into immutable copies
- expose new primitive in the compiler's primitive list
- document and test `bytes->immutable-bytes`

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8eb5b1d38832295594523a1bf1428