### PR TITLE
Add missing string primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -467,15 +467,18 @@
   bytes?  make-bytes  bytes-ref  bytes-set!  bytes-length  subbytes bytes-copy!
   bytes-copy bytes-fill! bytes-append bytes->immutable-bytes bytes->list list->bytes bytes=?
   bytes->string/utf-8
-  
+
   string? string=? string<?
   make-string string-ref string-set! string-length substring string-copy!
   string-copy string-fill! string-append string->list list->string
-  string->bytes/utf-8
+  string->bytes/utf-8 string->immutable-string string-replace
 
+  string-take        ; not in Racket
+  string-take-right  ; not in Racket
+  string-drop        ; not in Racket
+  string-drop-right  ; not in Racket
   string-trim-left   ; not in Racket
   string-trim-right  ; not in Racket
-  string-drop        ; not in Racket
 
   symbol? symbol=? symbol<?
   string->symbol symbol->string

--- a/priminfo.rkt
+++ b/priminfo.rkt
@@ -41,6 +41,11 @@
     string-trim-left
     string-trim-right
     string-drop         ; srfi 13
+    string-drop-right   ; srfi 13
+    string-take         ; srfi 13
+    string-take-right   ; srfi 13
+    string-replace      ; srfi 13
+    string->immutable-string
     make-void
     
     set-boxed!          ; assignment boxes


### PR DESCRIPTION
## Summary
- register more string-related primitives like `string->immutable-string` and `string-take`
- list corresponding SRFI-13 procedures in primitive metadata

## Testing
- `raco test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2577ab88322a60e3b9a134dffc9