### PR TITLE
Add case-insensitive character comparison primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -426,7 +426,13 @@
   char-titlecase
   char-upcase
   char-whitespace?
-  
+
+  char-ci=?
+  char-ci<?
+  char-ci<=?
+  char-ci>?
+  char-ci>=?
+
   eq?
   eqv?
   equal?
@@ -3006,7 +3012,8 @@
                                     (define m (- 5 n))
                                     (define falses (make-list m (Imm #f)))
                                     `(call $make-struct-field-mutator ,@aes ,@falses)]
-                                   [(char=? char<? char<=? char>? char>=?)
+                                   [(char=? char<? char<=? char>? char>=?
+                                     char-ci=? char-ci<? char-ci<=? char-ci>? char-ci>=?)
                                     ; variadic, at least one argument
                                     (define who    sym)
                                     (define n      (length ae1))

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -5494,15 +5494,15 @@
                              (else (global.get $false)))
                         `(return_call $eq? (local.get $c1) (local.get $c2)))))
 
-         ,@(for/list ([$cmp   (in-list '($char=?   $char<?   $char<=?   $char>?   $char>=?))]
-                      [$cmp/2 (in-list '($char=?/2 $char<?/2 $char<=?/2 $char>?/2 $char>=?/2))])
-             ; variadic version
-             `(func ,$cmp (param $c0 (ref eq)) (param $cs (ref eq)) (result (ref eq))
-                    (local $node  (ref $Pair))
-                    (local $ch    (ref eq))
-                    ;; Validate the first argument
-                    (if (ref.eq (call $char? (local.get $c0)) (global.get $false))
-                        (then (call $raise-check-char (local.get $c0))))
+        ,@(for/list ([$cmp   (in-list '($char=?   $char<?   $char<=?   $char>?   $char>=?))]
+                     [$cmp/2 (in-list '($char=?/2 $char<?/2 $char<=?/2 $char>?/2 $char>=?/2))])
+            ; variadic version
+            `(func ,$cmp (param $c0 (ref eq)) (param $cs (ref eq)) (result (ref eq))
+                   (local $node  (ref $Pair))
+                   (local $ch    (ref eq))
+                   ;; Validate the first argument
+                   (if (ref.eq (call $char? (local.get $c0)) (global.get $false))
+                       (then (call $raise-check-char (local.get $c0))))
                     (block $done
                            (loop $loop
                                  (br_if $done (ref.eq (local.get $cs) (global.get $null)))
@@ -5515,8 +5515,64 @@
                                              (global.get $false))
                                      (then (return (global.get $false))))
                                  (local.set $cs (struct.get $Pair $d (local.get $node)))
-                                 (br $loop)))
-                    (global.get $true)))
+                                (br $loop)))
+                   (global.get $true)))
+
+        ,@(for/list ([$cmp   (in-list '($char-ci=?   $char-ci<?   $char-ci<=?   $char-ci>?   $char-ci>=?))]
+                     [$cmp/2 (in-list '($char-ci=?/2 $char-ci<?/2 $char-ci<=?/2 $char-ci>?/2 $char-ci>=?/2))]
+                     [inst   (in-list '(#f i32.lt_u i32.le_u i32.gt_u i32.ge_u))])
+            ; binary case-insensitive version
+            `(func ,$cmp/2 (param $c1 (ref eq)) (param $c2 (ref eq)) (result (ref eq))
+                   (local $cp1 i32)
+                   (local $cp2 i32)
+                   (local $fc1 i32)
+                   (local $fc2 i32)
+                   ;; Ensure both arguments are characters
+                   (if (ref.eq (call $char? (local.get $c1)) (global.get $false))
+                       (then (call $raise-check-char (local.get $c1))))
+                   (if (ref.eq (call $char? (local.get $c2)) (global.get $false))
+                       (then (call $raise-check-char (local.get $c2))))
+                   ;; Extract codepoints
+                   (local.set $cp1 (i32.shr_u (i31.get_u (ref.cast (ref i31) (local.get $c1)))
+                                             (i32.const ,char-shift)))
+                   (local.set $cp2 (i32.shr_u (i31.get_u (ref.cast (ref i31) (local.get $c2)))
+                                             (i32.const ,char-shift)))
+                   ;; Foldcase codepoints
+                   (local.set $fc1 (call $char-foldcase/ucs (local.get $cp1)))
+                   (local.set $fc2 (call $char-foldcase/ucs (local.get $cp2)))
+                   ,(if inst
+                        `(if (result (ref eq))
+                             (,inst (local.get $fc1) (local.get $fc2))
+                             (then (global.get $true))
+                             (else (global.get $false)))
+                        `(if (result (ref eq))
+                             (i32.eq (local.get $fc1) (local.get $fc2))
+                             (then (global.get $true))
+                             (else (global.get $false)))))
+
+        ,@(for/list ([$cmp   (in-list '($char-ci=?   $char-ci<?   $char-ci<=?   $char-ci>?   $char-ci>=?))]
+                     [$cmp/2 (in-list '($char-ci=?/2 $char-ci<?/2 $char-ci<=?/2 $char-ci>?/2 $char-ci>=?/2))])
+            ; variadic case-insensitive version
+            `(func ,$cmp (param $c0 (ref eq)) (param $cs (ref eq)) (result (ref eq))
+                   (local $node  (ref $Pair))
+                   (local $ch    (ref eq))
+                   ;; Validate the first argument
+                   (if (ref.eq (call $char? (local.get $c0)) (global.get $false))
+                       (then (call $raise-check-char (local.get $c0))))
+                   (block $done
+                          (loop $loop
+                                (br_if $done (ref.eq (local.get $cs) (global.get $null)))
+                                (local.set $node (ref.cast (ref $Pair) (local.get $cs)))
+                                (local.set $ch   (struct.get $Pair $a (local.get $node)))
+                                ;; Validate each subsequent argument
+                                (if (ref.eq (call $char? (local.get $ch)) (global.get $false))
+                                    (then (call $raise-check-char (local.get $ch))))
+                                (if (ref.eq (call ,$cmp/2 (local.get $c0) (local.get $ch))
+                                            (global.get $false))
+                                    (then (return (global.get $false))))
+                                (local.set $cs (struct.get $Pair $d (local.get $node)))
+                                (br $loop)))
+                   (global.get $true)))
 
          (func $char->integer (param $c (ref eq)) (result (ref eq))
                (local $i31   (ref i31))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -138,6 +138,26 @@
             (equal? (char-foldcase #\space) #\space)
             (equal? (procedure-arity char-foldcase) 1)))
 
+ (list "char-ci=?"
+       (and (equal? (char-ci=? #\A #\a) #t)
+            (equal? (char-ci=? #\A #\B) #f)))
+
+ (list "char-ci<?"
+       (and (equal? (char-ci<? #\A #\b) #t)
+            (equal? (char-ci<? #\b #\A) #f)))
+
+ (list "char-ci<=?"
+       (and (equal? (char-ci<=? #\A #\a) #t)
+            (equal? (char-ci<=? #\b #\A) #f)))
+
+ (list "char-ci>?"
+       (and (equal? (char-ci>? #\B #\a) #t)
+            (equal? (char-ci>? #\A #\b) #f)))
+
+ (list "char-ci>=?"
+       (and (equal? (char-ci>=? #\A #\a) #t)
+            (equal? (char-ci>=? #\a #\B) #f)))
+
  (list "string-append"
        (and (equal? (string-append) "")
             (equal? (string-append "A") "A")


### PR DESCRIPTION
## Summary
- implement char-ci=?, char-ci<?, char-ci<=?, char-ci>?, and char-ci>=? primitives using `char-foldcase`
- expose case-insensitive character comparisons through the compiler
- add basic tests for new char-ci operations
- inline validation for char-ci primitives to report errors with correct stacks

------
https://chatgpt.com/codex/tasks/task_e_68ab033ae12c8322a29684c024e40ee7