### PR TITLE
Add Canvas element DOM bindings

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -592,6 +592,28 @@ var imports = {
         'tanh':   ((x)       => Math.tanh(x)),
         'trunc':  ((x)       => Math.trunc(x))
     },
+    // Canvas
+    'canvas': hasDOM ? {
+        'capture-stream':             ((canvas, rate)                 => canvas.captureStream(rate)),
+        'get-context':                ((canvas, type, opts)           => canvas.getContext(from_fasl(type), opts)),
+        'height':                     ((canvas)                       => canvas.height),
+        'set-height!':                ((canvas, h)                    => { canvas.height = h; }),
+        'to-blob':                    ((canvas, cb, type, quality)    => canvas.toBlob(cb, from_fasl(type), quality)),
+        'to-data-url':                ((canvas, type, quality)        => canvas.toDataURL(from_fasl(type), quality)),
+        'transfer-control-to-offscreen': ((canvas)                   => canvas.transferControlToOffscreen()),
+        'width':                      ((canvas)                       => canvas.width),
+        'set-width!':                 ((canvas, w)                    => { canvas.width = w; })
+    } : {
+        'capture-stream'()             { throw new Error('DOM not available in this environment'); },
+        'get-context'()                { throw new Error('DOM not available in this environment'); },
+        'height'()                     { throw new Error('DOM not available in this environment'); },
+        'set-height!'()                { throw new Error('DOM not available in this environment'); },
+        'to-blob'()                    { throw new Error('DOM not available in this environment'); },
+        'to-data-url'()                { throw new Error('DOM not available in this environment'); },
+        'transfer-control-to-offscreen'() { throw new Error('DOM not available in this environment'); },
+        'width'()                      { throw new Error('DOM not available in this environment'); },
+        'set-width!'()                 { throw new Error('DOM not available in this environment'); }
+    },
     // Document
     'document': hasDOM ? {
         'body':                     (()                               => document.body),

--- a/dom.ffi
+++ b/dom.ffi
@@ -540,4 +540,55 @@
   ;; The force argument is optional; pass 0/1. Undefined not supported.
   (-> (extern string i32) (i32)))
 
+;;;
+;;; Canvas
+;;;
+
+; https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement
+
+(define-foreign js-canvas-capture-stream
+  #:module "canvas"
+  #:name   "capture-stream"
+  (-> (extern f64) (extern)))
+
+(define-foreign js-canvas-get-context
+  #:module "canvas"
+  #:name   "get-context"
+  (-> (extern string extern) (extern)))
+
+(define-foreign js-canvas-height
+  #:module "canvas"
+  #:name   "height"
+  (-> (extern) (u32)))
+
+(define-foreign js-set-canvas-height!
+  #:module "canvas"
+  #:name   "set-height!"
+  (-> (extern u32) ()))
+
+(define-foreign js-canvas-to-blob
+  #:module "canvas"
+  #:name   "to-blob"
+  (-> (extern extern string f64) ()))
+
+(define-foreign js-canvas-to-data-url
+  #:module "canvas"
+  #:name   "to-data-url"
+  (-> (extern string f64) (string)))
+
+(define-foreign js-canvas-transfer-control-to-offscreen
+  #:module "canvas"
+  #:name   "transfer-control-to-offscreen"
+  (-> (extern) (extern)))
+
+(define-foreign js-canvas-width
+  #:module "canvas"
+  #:name   "width"
+  (-> (extern) (u32)))
+
+(define-foreign js-set-canvas-width!
+  #:module "canvas"
+  #:name   "set-width!"
+  (-> (extern u32) ()))
+
 

--- a/runtime.js
+++ b/runtime.js
@@ -519,6 +519,28 @@ var imports = {
         'tanh':   ((x)       => Math.tanh(x)),
         'trunc':  ((x)       => Math.trunc(x))
     },
+    // Canvas
+    'canvas': hasDOM ? {
+        'capture-stream':             ((canvas, rate)                 => canvas.captureStream(rate)),
+        'get-context':                ((canvas, type, opts)           => canvas.getContext(from_fasl(type), opts)),
+        'height':                     ((canvas)                       => canvas.height),
+        'set-height!':                ((canvas, h)                    => { canvas.height = h; }),
+        'to-blob':                    ((canvas, cb, type, quality)    => canvas.toBlob(cb, from_fasl(type), quality)),
+        'to-data-url':                ((canvas, type, quality)        => canvas.toDataURL(from_fasl(type), quality)),
+        'transfer-control-to-offscreen': ((canvas)                   => canvas.transferControlToOffscreen()),
+        'width':                      ((canvas)                       => canvas.width),
+        'set-width!':                 ((canvas, w)                    => { canvas.width = w; })
+    } : {
+        'capture-stream'()             { throw new Error('DOM not available in this environment'); },
+        'get-context'()                { throw new Error('DOM not available in this environment'); },
+        'height'()                     { throw new Error('DOM not available in this environment'); },
+        'set-height!'()                { throw new Error('DOM not available in this environment'); },
+        'to-blob'()                    { throw new Error('DOM not available in this environment'); },
+        'to-data-url'()                { throw new Error('DOM not available in this environment'); },
+        'transfer-control-to-offscreen'() { throw new Error('DOM not available in this environment'); },
+        'width'()                      { throw new Error('DOM not available in this environment'); },
+        'set-width!'()                 { throw new Error('DOM not available in this environment'); }
+    },
     // Document
     'document': hasDOM ? {
         'body':                     (()                               => document.body),


### PR DESCRIPTION
## Summary
- add FFI definitions for HTMLCanvasElement properties and methods
- expose Canvas APIs in runtime and assembler

## Testing
- `raco test ./...` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7daf28408322b399ca67e36a607d