### PR TITLE
Add helpers for decoding FASL from linear memory

### DIFF
--- a/test/linear-memory.rkt
+++ b/test/linear-memory.rkt
@@ -1,0 +1,16 @@
+(list
+ (list "linear-memory->string"
+       (let* ([bs (s-exp->fasl "hello" #f)]
+              [_  (copy-bytes-to-memory bs 0)])
+         (equal? (linear-memory->string 0) "hello")))
+ (list "linear-memory->value"
+       (let* ([v  '(1 . 2)]
+              [bs (s-exp->fasl v #f)]
+              [_  (copy-bytes-to-memory bs 0)])
+         (equal? (linear-memory->value 0) v)))
+ (list "linear-memory->string-negative"
+       (with-handlers ([exn:fail? (lambda (_) #t)])
+         (let* ([bs (s-exp->fasl 42 #f)]
+                [_  (copy-bytes-to-memory bs 0)])
+           (linear-memory->string 0)
+           #f))))


### PR DESCRIPTION
## Summary
- add WebAssembly helpers to copy FASL bytes from linear memory and decode them
- expose linear-memory->value and linear-memory->string for FFI use
- cover decoding helpers with tests

## Testing
- `node runtime.js` *(fails: ENOENT: no such file or directory, open 'out.wasm')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f06aba08322a3db41c789c7c32d