### PR TITLE
Add string-based canvas fill style setter

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -621,6 +621,7 @@ var imports = {
         'set-direction!':         ((ctx, dir) => { ctx.direction = from_fasl(dir); }),
         'fill-style':             (ctx => ctx.fillStyle),
         'set-fill-style!':        ((ctx, style) => { ctx.fillStyle = style; }),
+        'set-fill-style!/string': ((ctx, style) => { ctx.fillStyle = from_fasl(style); }),
         'filter':                 (ctx => ctx.filter),
         'set-filter!':            ((ctx, filter) => { ctx.filter = from_fasl(filter); }),
         'font':                   (ctx => ctx.font),


### PR DESCRIPTION
## Summary
- implement `js-set-canvas2d-fill-style!/string` in assembler

## Testing
- `raco test test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9b4ba59c832291ed7bfb2cbe84e7