### PR TITLE
Handle optional arguments for canvas fill

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -693,7 +693,20 @@ var imports = {
         'draw-image-5': ((ctx, img, dx, dy, dw, dh) => ctx.drawImage(img, dx, dy, dw, dh)),
         'draw-image-9': ((ctx, img, sx, sy, sw, sh, dx, dy, dw, dh) => ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh)),
         'ellipse': ((ctx, x, y, rx, ry, rot, sa, ea, ccw) => ctx.ellipse(x, y, rx, ry, rot, sa, ea, !!ccw)),
-        'fill': ((ctx, path, rule) => ctx.fill(path, from_fasl(rule))),
+        'fill': ((ctx, path, rule) => {
+          // `(void)` from Racket arrives as `undefined` in JS.
+          const p = (path === undefined) ? undefined : path;
+          const r = (rule === undefined) ? undefined : rule;
+          if (p === undefined && r === undefined) {
+            ctx.fill();
+          } else if (p === undefined) {
+            ctx.fill(from_fasl(r));
+          } else if (r === undefined) {
+            ctx.fill(p);
+          } else {
+            ctx.fill(p, from_fasl(r));
+          }
+        }),
         'fill-rect': ((ctx, x, y, w, h) => ctx.fillRect(x, y, w, h)),
         'fill-text': ((ctx, text, x, y, mw) => ctx.fillText(from_fasl(text), x, y, mw)),
         'get-image-data': ((ctx, sx, sy, sw, sh, opts) => ctx.getImageData(sx, sy, sw, sh, opts)),

--- a/dom.ffi
+++ b/dom.ffi
@@ -980,6 +980,7 @@
 (define-foreign js-canvas2d-fill
   #:module "canvas-rendering-context-2d"
   #:name   "fill"
+  ;; Pass `(void)` for missing optional arguments; it becomes JS `undefined`.
   #;(-> (extern) ())
   #;(-> (extern value) ())       ; path
   #;(-> (extern value) ())       ; fillRule

--- a/test/canvas-star.rkt
+++ b/test/canvas-star.rkt
@@ -24,7 +24,7 @@
     (js-canvas2d-line-to ctx x2 y2)
     (set! rot (+ rot step)))
   (js-canvas2d-close-path ctx)
-  (js-canvas2d-fill ctx "nonzero" (void)) ; void becomes undefined
+  (js-canvas2d-fill ctx (void) "nonzero") ; void becomes undefined
   (js-canvas2d-stroke ctx))
 
 (draw-star ctx 150. 150. 5 100. 40.)


### PR DESCRIPTION
## Summary
- Support optional path and rule parameters in `canvas` fill wrapper, converting Racket `void` to JavaScript `undefined`
- Adjust star drawing test to pass `(void)` when omitting a `Path2D`
- Document the `(void)`-as-`undefined` convention for `js-canvas2d-fill` in `dom.ffi`

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68ac2e478c6c8322834a7f799d647f92