### PR TITLE
Add canvas example drawing image

### DIFF
--- a/test/canvas-image.rkt
+++ b/test/canvas-image.rkt
@@ -1,0 +1,13 @@
+(define canvas (js-create-element "canvas"))
+(js-set-canvas-width!  canvas 300)
+(js-set-canvas-height! canvas 300)
+(js-append-child! (js-document-body) canvas)
+
+(define ctx (js-canvas-get-context canvas "2d" (js-undefined)))
+
+(define img (js-create-element "img"))
+(js-set-attribute! img "src" "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC")
+(js-set-attribute! img "style" "display:none")
+(js-append-child! (js-document-body) img)
+
+(js-canvas2d-draw-image-5 ctx img 0. 0. 300. 300.)


### PR DESCRIPTION
## Summary
- Add canvas demo that loads a base64 image and draws it onto a canvas.

## Testing
- `racket test/canvas-image.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9bbbb5d48322be67008b342d0cc9