### PR TITLE
Add Event FFI bindings and wrappers

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -1309,6 +1309,48 @@ var imports = {
         'y'() { throw new Error('DOM not available in this environment'); },
         'decode'() { throw new Error('DOM not available in this environment'); }
     },
+    // Event
+    'event': hasDOM ? {
+        'new': ((type, init) => {
+            const t = from_fasl(type);
+            const i = from_fasl(init);
+            if (i === undefined) {
+                return new Event(t);
+            } else {
+                return new Event(t, i);
+            }
+        }),
+        'type': (evt => evt.type),
+        'target': (evt => evt.target),
+        'current-target': (evt => evt.currentTarget),
+        'event-phase': (evt => evt.eventPhase),
+        'bubbles': (evt => evt.bubbles ? 1 : 0),
+        'cancelable': (evt => evt.cancelable ? 1 : 0),
+        'default-prevented': (evt => evt.defaultPrevented ? 1 : 0),
+        'composed': (evt => evt.composed ? 1 : 0),
+        'is-trusted': (evt => evt.isTrusted ? 1 : 0),
+        'time-stamp': (evt => evt.timeStamp),
+        'composed-path': (evt => evt.composedPath()),
+        'prevent-default': (evt => evt.preventDefault()),
+        'stop-propagation': (evt => evt.stopPropagation()),
+        'stop-immediate-propagation': (evt => evt.stopImmediatePropagation())
+    } : {
+        'new'() { throw new Error('DOM not available in this environment'); },
+        'type'() { throw new Error('DOM not available in this environment'); },
+        'target'() { throw new Error('DOM not available in this environment'); },
+        'current-target'() { throw new Error('DOM not available in this environment'); },
+        'event-phase'() { throw new Error('DOM not available in this environment'); },
+        'bubbles'() { throw new Error('DOM not available in this environment'); },
+        'cancelable'() { throw new Error('DOM not available in this environment'); },
+        'default-prevented'() { throw new Error('DOM not available in this environment'); },
+        'composed'() { throw new Error('DOM not available in this environment'); },
+        'is-trusted'() { throw new Error('DOM not available in this environment'); },
+        'time-stamp'() { throw new Error('DOM not available in this environment'); },
+        'composed-path'() { throw new Error('DOM not available in this environment'); },
+        'prevent-default'() { throw new Error('DOM not available in this environment'); },
+        'stop-propagation'() { throw new Error('DOM not available in this environment'); },
+        'stop-immediate-propagation'() { throw new Error('DOM not available in this environment'); }
+    },
     // Element
     'element': hasDOM ? {
         'append-child!':           ((parent, child)          => parent.appendChild(child)),

--- a/dom.ffi
+++ b/dom.ffi
@@ -729,6 +729,91 @@
   #:module "document"
   #:name   "writeln"
   (-> (string) ()))
+ 
+
+;;; Event
+;;;
+; The various functions in this section are documented here:
+;
+;     https://developer.mozilla.org/en-US/docs/Web/API/Event
+;
+(define-foreign js-event-new
+  #:module "event"
+  #:name   "new"
+  ;; Pass `(void)` for missing optional arguments; it becomes JS `undefined`.
+  (-> (string value) (extern)))
+
+;; Properties
+(define-foreign js-event-type
+  #:module "event"
+  #:name   "type"
+  (-> (extern) (string)))
+
+(define-foreign js-event-target
+  #:module "event"
+  #:name   "target"
+  (-> (extern) (extern)))
+
+(define-foreign js-event-current-target
+  #:module "event"
+  #:name   "current-target"
+  (-> (extern) (extern)))
+
+(define-foreign js-event-event-phase
+  #:module "event"
+  #:name   "event-phase"
+  (-> (extern) (u32)))
+
+(define-foreign js-event-bubbles
+  #:module "event"
+  #:name   "bubbles"
+  (-> (extern) (i32)))
+
+(define-foreign js-event-cancelable
+  #:module "event"
+  #:name   "cancelable"
+  (-> (extern) (i32)))
+
+(define-foreign js-event-default-prevented
+  #:module "event"
+  #:name   "default-prevented"
+  (-> (extern) (i32)))
+
+(define-foreign js-event-composed
+  #:module "event"
+  #:name   "composed"
+  (-> (extern) (i32)))
+
+(define-foreign js-event-is-trusted
+  #:module "event"
+  #:name   "is-trusted"
+  (-> (extern) (i32)))
+
+(define-foreign js-event-time-stamp
+  #:module "event"
+  #:name   "time-stamp"
+  (-> (extern) (f64)))
+
+;; Methods
+(define-foreign js-event-composed-path
+  #:module "event"
+  #:name   "composed-path"
+  (-> (extern) (extern)))
+
+(define-foreign js-event-prevent-default
+  #:module "event"
+  #:name   "prevent-default"
+  (-> (extern) ()))
+
+(define-foreign js-event-stop-propagation
+  #:module "event"
+  #:name   "stop-propagation"
+  (-> (extern) ()))
+
+(define-foreign js-event-stop-immediate-propagation
+  #:module "event"
+  #:name   "stop-immediate-propagation"
+  (-> (extern) ()))
 
 
 ;;;


### PR DESCRIPTION
## Summary
- add DOM Event FFI bindings for constructor, properties, and methods
- implement assembler wrappers for Event API, handling optional constructor args

## Testing
- `raco test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68accd4c3a3c8322bb0b3a2e62848a45