### PR TITLE
Initialize primitive invoke locals to avoid Wasm validation error

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -808,6 +808,10 @@
               (local $argc i32)
               (local $a0 (ref eq)) (local $a1 (ref eq)) (local $a2 (ref eq))
 
+              (local.set $a0 (global.get $null))
+              (local.set $a1 (global.get $null))
+              (local.set $a2 (global.get $null))
+
               ;; Proc -> PrimitiveProcedure
               (local.set $pproc
                          (ref.cast (ref $PrimitiveProcedure) (local.get $proc)))


### PR DESCRIPTION
## Summary
- Initialize scratch argument locals in `primitive-invoke` to a default value so WebAssembly validation succeeds

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae22c9862c83229f4f3621843af484