### PR TITLE
Add call-with-values primitive

### DIFF
--- a/primitives.rkt
+++ b/primitives.rkt
@@ -116,6 +116,9 @@ char-upcase
  ; cdar
  ; cddr
 
+ ;; 10.1 Multiple Values
+ values
+ call-with-values
 
  ;; 10.2 Exceptions
  raise-argument-error

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -424,6 +424,11 @@
  (list "map-prim2"
        (equal? (map eq? '(a b) '(a c)) '(#t #f)))
 
+ (list "call-with-values"
+       (and (equal? (call-with-values (lambda () (values 1 2)) +) 3)
+            (with-handlers ([exn:fail:contract? (λ _ #t)])
+              (call-with-values (lambda () 1) (lambda (x y) (+ x y))))))
+
  #;(list "apply-prim>=0"
-       (equal? (apply + '(1 2 3)) 6))
+        (equal? (apply + '(1 2 3)) 6))
 )


### PR DESCRIPTION
## Summary
- implement `call-with-values` to forward generator results to a receiver
- expose `values` and `call-with-values` in the primitives list
- cover `call-with-values` with a basic test

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2cbf3bfc8322ac2cbcd4ecef4cb5