### PR TITLE
Add string comparison primitives

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -5444,8 +5444,46 @@
                ;; If one is a prefix of the other
                (return (i32.lt_u (local.get $len-a) (local.get $len-b))))
 
-         
-         ;;; 
+         (func $string<=? (type $Prim2)
+               (param $a (ref eq)) (param $b (ref eq))
+               (result (ref eq))
+               (if (result (ref eq)) (call $string<=/i32 (local.get $a) (local.get $b))
+                   (then (global.get $true))
+                   (else (global.get $false))))
+
+         (func $string<=/i32
+               (param $a-raw (ref eq)) (param $b-raw (ref eq))
+               (result i32)
+               (return (i32.or (call $string</i32 (local.get $a-raw) (local.get $b-raw))
+                                (call $string=?/i32 (local.get $a-raw) (local.get $b-raw)))))
+
+         (func $string>? (type $Prim2)
+               (param $a (ref eq)) (param $b (ref eq))
+               (result (ref eq))
+               (if (result (ref eq)) (call $string>/i32 (local.get $a) (local.get $b))
+                   (then (global.get $true))
+                   (else (global.get $false))))
+
+         (func $string>/i32
+               (param $a-raw (ref eq)) (param $b-raw (ref eq))
+               (result i32)
+               (return_call $string</i32 (local.get $b-raw) (local.get $a-raw)))
+
+         (func $string>=? (type $Prim2)
+               (param $a (ref eq)) (param $b (ref eq))
+               (result (ref eq))
+               (if (result (ref eq)) (call $string>=/i32 (local.get $a) (local.get $b))
+                   (then (global.get $true))
+                   (else (global.get $false))))
+
+         (func $string>=/i32
+               (param $a-raw (ref eq)) (param $b-raw (ref eq))
+               (result i32)
+               (return (i32.or (call $string</i32 (local.get $b-raw) (local.get $a-raw))
+                                (call $string=?/i32 (local.get $a-raw) (local.get $b-raw)))))
+
+
+         ;;;
 
          (func $raise-invalid-utf8-input (param $bad (ref eq)) (result (ref eq)) (unreachable))
 


### PR DESCRIPTION
## Summary
- implement `string<=?` using existing `<` and `=` checks
- add `string>?` and `string>=?` leveraging `string<?`

## Testing
- `raco test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b745b248322a8dc709ec02a622d