### PR TITLE
Add Array FFI bindings

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -592,6 +592,84 @@ var imports = {
         'tanh':   ((x)       => Math.tanh(x)),
         'trunc':  ((x)       => Math.trunc(x))
     },
+    'array': {
+        'length':            (arr => arr.length),
+        'set-length!':       ((arr, len) => { arr.length = len; }),
+        'from':              ((arrLike, mapFn, thisArg) => {
+            const a = from_fasl(arrLike);
+            const m = mapFn;
+            const t = from_fasl(thisArg);
+            if (m === undefined) {
+                return Array.from(a);
+            } else if (t === undefined) {
+                return Array.from(a, m);
+            } else {
+                return Array.from(a, m, t);
+            }
+        }),
+        'from-async':        ((arrLike, mapFn, thisArg) => {
+            const a = from_fasl(arrLike);
+            const m = mapFn;
+            const t = from_fasl(thisArg);
+            if (m === undefined) {
+                return Array.fromAsync(a);
+            } else if (t === undefined) {
+                return Array.fromAsync(a, m);
+            } else {
+                return Array.fromAsync(a, m, t);
+            }
+        }),
+        'is-array':          (v => Array.isArray(from_fasl(v)) ? 1 : 0),
+        'of':                (items => Array.of(...(from_fasl(items) || []))),
+        'at':                ((arr, index) => arr.at(index)),
+        'concat':            ((arr, items) => arr.concat(...(from_fasl(items) || []))),
+        'copy-within':       ((arr, target, start, end) => {
+            const e = from_fasl(end);
+            return e === undefined ? arr.copyWithin(target, start)
+                                   : arr.copyWithin(target, start, e);
+        }),
+        'entries':           (arr => arr.entries()),
+        'every':             ((arr, fn, thisArg) => arr.every(fn, from_fasl(thisArg)) ? 1 : 0),
+        'fill':              ((arr, value, start, end) => arr.fill(from_fasl(value), from_fasl(start), from_fasl(end))),
+        'filter':            ((arr, fn, thisArg) => arr.filter(fn, from_fasl(thisArg))),
+        'find':              ((arr, fn, thisArg) => arr.find(fn, from_fasl(thisArg))),
+        'find-index':        ((arr, fn, thisArg) => arr.findIndex(fn, from_fasl(thisArg))),
+        'find-last':         ((arr, fn, thisArg) => arr.findLast(fn, from_fasl(thisArg))),
+        'find-last-index':   ((arr, fn, thisArg) => arr.findLastIndex(fn, from_fasl(thisArg))),
+        'flat':              ((arr, depth) => arr.flat(from_fasl(depth))),
+        'flat-map':          ((arr, fn, thisArg) => arr.flatMap(fn, from_fasl(thisArg))),
+        'for-each':          ((arr, fn, thisArg) => { arr.forEach(fn, from_fasl(thisArg)); }),
+        'includes':          ((arr, value, fromIndex) => arr.includes(from_fasl(value), from_fasl(fromIndex)) ? 1 : 0),
+        'index-of':          ((arr, value, fromIndex) => arr.indexOf(from_fasl(value), from_fasl(fromIndex))),
+        'join':              ((arr, sep) => arr.join(from_fasl(sep))),
+        'keys':              (arr => arr.keys()),
+        'last-index-of':     ((arr, value, fromIndex) => arr.lastIndexOf(from_fasl(value), from_fasl(fromIndex))),
+        'map':               ((arr, fn, thisArg) => arr.map(fn, from_fasl(thisArg))),
+        'pop':               (arr => arr.pop()),
+        'push':              ((arr, items) => arr.push(...(from_fasl(items) || []))),
+        'reduce':            ((arr, fn, init) => {
+            const i = from_fasl(init);
+            return i === undefined ? arr.reduce(fn) : arr.reduce(fn, i);
+        }),
+        'reduce-right':      ((arr, fn, init) => {
+            const i = from_fasl(init);
+            return i === undefined ? arr.reduceRight(fn) : arr.reduceRight(fn, i);
+        }),
+        'reverse':           (arr => arr.reverse()),
+        'shift':             (arr => arr.shift()),
+        'slice':             ((arr, start, end) => arr.slice(from_fasl(start), from_fasl(end))),
+        'some':              ((arr, fn, thisArg) => arr.some(fn, from_fasl(thisArg)) ? 1 : 0),
+        'sort':              ((arr, fn) => arr.sort(fn)),
+        'splice':            ((arr, items) => arr.splice(...(from_fasl(items) || []))),
+        'to-locale-string':  ((arr, args) => arr.toLocaleString(...(from_fasl(args) || []))),
+        'to-string':         (arr => arr.toString()),
+        'unshift':           ((arr, items) => arr.unshift(...(from_fasl(items) || []))),
+        'values':            (arr => arr.values()),
+        'to-reversed':       (arr => (arr.toReversed ? arr.toReversed() : [...arr].reverse())),
+        'to-sorted':         ((arr, fn) => (arr.toSorted ? arr.toSorted(fn) : [...arr].sort(fn))),
+        'to-spliced':        ((arr, items) => (arr.toSpliced ? arr.toSpliced(...(from_fasl(items) || [])) : (() => { const b = arr.slice(); b.splice(...(from_fasl(items) || [])); return b; })())),
+        'with':              ((arr, index, value) => (arr.with ? arr.with(index, from_fasl(value)) : (() => { const b = arr.slice(); b[index] = from_fasl(value); return b; })())),
+    },
     // Canvas
     'canvas': hasDOM ? {
         'capture-stream':                ((canvas, rate)                 => canvas.captureStream(rate)),

--- a/js.ffi
+++ b/js.ffi
@@ -1,0 +1,266 @@
+;;; 
+;;; JavaScript
+;;;
+
+;; This file declares foreign function bindings for builtin JavaScript
+;; arrays.
+;;
+;; See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+;;; Static methods
+
+(define-foreign js-array-from
+  #:module "array"
+  #:name   "from"
+  ;; Pass `(void)` for missing map function and this argument.
+  (-> (value extern value) (extern)))
+
+(define-foreign js-array-from-async
+  #:module "array"
+  #:name   "from-async"
+  ;; Pass `(void)` for missing map function and this argument.
+  (-> (value extern value) (extern)))
+
+(define-foreign js-array-is-array
+  #:module "array"
+  #:name   "is-array"
+  (-> (value) (i32)))
+
+(define-foreign js-array-of
+  #:module "array"
+  #:name   "of"
+  ;; `items` should be a list or vector.
+  (-> (value) (extern)))
+
+;;; Properties
+
+(define-foreign js-array-length
+  #:module "array"
+  #:name   "length"
+  (-> (extern) (u32)))
+
+(define-foreign js-set-array-length!
+  #:module "array"
+  #:name   "set-length!"
+  (-> (extern u32) ()))
+
+;;; Methods
+
+(define-foreign js-array-at
+  #:module "array"
+  #:name   "at"
+  (-> (extern i32) (value)))
+
+(define-foreign js-array-concat
+  #:module "array"
+  #:name   "concat"
+  ;; `items` should be a list or vector.
+  (-> (extern value) (extern)))
+
+(define-foreign js-array-copy-within
+  #:module "array"
+  #:name   "copy-within"
+  ;; Pass `(void)` for missing end.
+  (-> (extern i32 i32 value) (extern)))
+
+(define-foreign js-array-entries
+  #:module "array"
+  #:name   "entries"
+  (-> (extern) (extern)))
+
+(define-foreign js-array-every
+  #:module "array"
+  #:name   "every"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (i32)))
+
+(define-foreign js-array-fill
+  #:module "array"
+  #:name   "fill"
+  ;; Pass `(void)` for missing start and end.
+  (-> (extern value value value) (extern)))
+
+(define-foreign js-array-filter
+  #:module "array"
+  #:name   "filter"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (extern)))
+
+(define-foreign js-array-find
+  #:module "array"
+  #:name   "find"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (value)))
+
+(define-foreign js-array-find-index
+  #:module "array"
+  #:name   "find-index"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (i32)))
+
+(define-foreign js-array-find-last
+  #:module "array"
+  #:name   "find-last"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (value)))
+
+(define-foreign js-array-find-last-index
+  #:module "array"
+  #:name   "find-last-index"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (i32)))
+
+(define-foreign js-array-flat
+  #:module "array"
+  #:name   "flat"
+  ;; Pass `(void)` for missing depth.
+  (-> (extern value) (extern)))
+
+(define-foreign js-array-flat-map
+  #:module "array"
+  #:name   "flat-map"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (extern)))
+
+(define-foreign js-array-for-each
+  #:module "array"
+  #:name   "for-each"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) ()))
+
+(define-foreign js-array-includes
+  #:module "array"
+  #:name   "includes"
+  ;; Pass `(void)` for missing from-index.
+  (-> (extern value value) (i32)))
+
+(define-foreign js-array-index-of
+  #:module "array"
+  #:name   "index-of"
+  ;; Pass `(void)` for missing from-index.
+  (-> (extern value value) (i32)))
+
+(define-foreign js-array-join
+  #:module "array"
+  #:name   "join"
+  ;; Pass `(void)` for missing separator.
+  (-> (extern value) (string)))
+
+(define-foreign js-array-keys
+  #:module "array"
+  #:name   "keys"
+  (-> (extern) (extern)))
+
+(define-foreign js-array-last-index-of
+  #:module "array"
+  #:name   "last-index-of"
+  ;; Pass `(void)` for missing from-index.
+  (-> (extern value value) (i32)))
+
+(define-foreign js-array-map
+  #:module "array"
+  #:name   "map"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (extern)))
+
+(define-foreign js-array-pop
+  #:module "array"
+  #:name   "pop"
+  (-> (extern) (value)))
+
+(define-foreign js-array-push
+  #:module "array"
+  #:name   "push"
+  ;; `items` should be a list or vector.
+  (-> (extern value) (u32)))
+
+(define-foreign js-array-reduce
+  #:module "array"
+  #:name   "reduce"
+  ;; Pass `(void)` for missing initial-value.
+  (-> (extern extern value) (value)))
+
+(define-foreign js-array-reduce-right
+  #:module "array"
+  #:name   "reduce-right"
+  ;; Pass `(void)` for missing initial-value.
+  (-> (extern extern value) (value)))
+
+(define-foreign js-array-reverse
+  #:module "array"
+  #:name   "reverse"
+  (-> (extern) (extern)))
+
+(define-foreign js-array-shift
+  #:module "array"
+  #:name   "shift"
+  (-> (extern) (value)))
+
+(define-foreign js-array-slice
+  #:module "array"
+  #:name   "slice"
+  ;; Pass `(void)` for missing start and end.
+  (-> (extern value value) (extern)))
+
+(define-foreign js-array-some
+  #:module "array"
+  #:name   "some"
+  ;; Pass `(void)` for missing this-arg.
+  (-> (extern extern value) (i32)))
+
+(define-foreign js-array-sort
+  #:module "array"
+  #:name   "sort"
+  ;; Pass `(void)` for missing compare-function.
+  (-> (extern extern) (extern)))
+
+(define-foreign js-array-splice
+  #:module "array"
+  #:name   "splice"
+  ;; `items` should be a list or vector.
+  (-> (extern value) (extern)))
+
+(define-foreign js-array-to-locale-string
+  #:module "array"
+  #:name   "to-locale-string"
+  ;; Pass `(void)` for missing locales/options (as a list).
+  (-> (extern value) (string)))
+
+(define-foreign js-array-to-string
+  #:module "array"
+  #:name   "to-string"
+  (-> (extern) (string)))
+
+(define-foreign js-array-unshift
+  #:module "array"
+  #:name   "unshift"
+  ;; `items` should be a list or vector.
+  (-> (extern value) (u32)))
+
+(define-foreign js-array-values
+  #:module "array"
+  #:name   "values"
+  (-> (extern) (extern)))
+
+(define-foreign js-array-to-reversed
+  #:module "array"
+  #:name   "to-reversed"
+  (-> (extern) (extern)))
+
+(define-foreign js-array-to-sorted
+  #:module "array"
+  #:name   "to-sorted"
+  ;; Pass `(void)` for missing compare-function.
+  (-> (extern extern) (extern)))
+
+(define-foreign js-array-to-spliced
+  #:module "array"
+  #:name   "to-spliced"
+  ;; `items` should be a list or vector.
+  (-> (extern value) (extern)))
+
+(define-foreign js-array-with
+  #:module "array"
+  #:name   "with"
+  (-> (extern i32 value) (extern)))
+


### PR DESCRIPTION
## Summary
- add `js.ffi` with JavaScript Array FFI bindings covering static methods, properties, and prototype methods
- implement corresponding host functions for arrays in `assembler.rkt`

## Testing
- `raco test test/test-basics.rkt` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b023bd0a5483229455f750438ce95d