### PR TITLE
Add callback registry for callback functions

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -702,7 +702,14 @@
          ;; Namespaces
          (global $top-level-namespace (mut (ref null $Namespace)) (ref.null $Namespace))
 
-         
+         ;; Callback registry
+         (global $callback-registry (ref $GrowableArray)
+                 (struct.new $GrowableArray
+                             (array.new $Array (global.get $false) (i32.const 4))
+                             (i32.const 4)
+                             (i32.const 0)))
+
+
          ;; Primitives (as values)
          ,@(declare-primitives-as-globals)
 
@@ -1603,6 +1610,16 @@
                (local $n i32)
                (local.set $n (array.len (local.get $a)))
                (struct.new $GrowableArray (local.get $a) (local.get $n) (local.get $n)))
+
+         (func $callback-register (export "callback-register")
+               (param $p (ref $Procedure))
+               (result i32)
+               (local $g (ref $GrowableArray))
+               (local $i i32)
+               (local.set $g (global.get $callback-registry))
+               (local.set $i (call $growable-array-count (local.get $g)))
+               (call $growable-array-add! (local.get $g) (local.get $p))
+               (local.get $i))
 
          
 


### PR DESCRIPTION
## Summary
- introduce global callback registry to map indices to procedures
- add exported `callback-register` helper to store callbacks
- fetch callback index via `growable-array-count`

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found: raco)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed.)*
- `apt-get install -y racket` *(fails: Unable to locate package racket)*

------
https://chatgpt.com/codex/tasks/task_e_68b0350759348322b6e5d9cf14da1402