### PR TITLE
Implement host callback invocation and add test

### DIFF
--- a/test/test-callback.rkt
+++ b/test/test-callback.rkt
@@ -1,0 +1,10 @@
+(list
+ (list "callback"
+       (let* ([p   (lambda (a b) (+ a b))]
+              [id  (callback-register p)]
+              [bs  (s-exp->fasl (vector 1 2) #f)]
+              [_   (copy-bytes-to-memory bs 0)]
+              [_len (callback id 0)]
+              [res (linear-memory->value 0)])
+         (equal? res 3))))
+


### PR DESCRIPTION
## Summary
- export `$callback` to invoke registered procedures with FASL-decoded arguments and return the result as FASL bytes
- add integration test covering callback registration and invocation

## Testing
- `raco test test/test-callback.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b03c0dde448322a0ee748dd93a2053