### PR TITLE
Expose procedure->external as primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -545,6 +545,7 @@
   apply
   procedure-rename
   procedure?
+  procedure->external
   procedure-arity
   procedure-arity-mask
   procedure-arity-includes?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -185,12 +185,18 @@
 
  s-exp->fasl
  fasl->s-exp
+ procedure->external
  js_log
 
 )
 
 (define (js_log v)
   (displayln v))
+
+(define (procedure->external p)
+  (unless (procedure? p)
+    (raise-argument-error 'procedure->external "procedure?" p))
+  p)
 
 
 ;; Changed in version 8.15.0.7: Added string-find.

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -9688,12 +9688,13 @@
                                 (i32.const 0)))
                (local.get $len))
 
-         (func $procedure->external
+         (func $procedure->external (export "procedure->external")
                (param $proc (ref eq))
-               (result (ref extern))
+               (result (ref eq))
 
                (local $p  (ref $Procedure))
                (local $id i32)
+               (local $cb (ref extern))
 
                ;; Fail-early type check
                (if (i32.eqz (ref.test (ref $Procedure) (local.get $proc)))
@@ -9702,9 +9703,12 @@
 
                (local.set $p (ref.cast (ref $Procedure) (local.get $proc)))
                (local.set $id (call $callback-register (local.get $p)))
+               (local.set $cb (call $js-make-callback (local.get $id)))
 
-               ;; Ask JS to build a callable extern function that forwards to (export "callback")
-               (call $js-make-callback (local.get $id)))
+               ;; Wrap extern callback as a Racket external value
+               (struct.new $External
+                           (i32.const 0)
+                           (local.get $cb)))
 
          ;;;
          ;;; STRUCTURES

--- a/runtime.js
+++ b/runtime.js
@@ -7,6 +7,8 @@ var memory = new WebAssembly.Memory({initial:1024});
 
 var output_string = [];
 
+let instance;
+
 function read_u32(arr, i) {
   return ((arr[i] << 24) | (arr[i + 1] << 16) |
           (arr[i + 2] << 8)  | arr[i + 3]) >>> 0;
@@ -394,6 +396,16 @@ var imports = {
         const s = String.fromCodePoint(cp).toLowerCase();
         const arr = Array.from(s);
         return (arr.length === 1) ? arr[0].codePointAt(0) : cp;
+      }),
+      'make_callback': ((id) => {
+        return (...args) => {
+          const bytes = js_value_to_fasl(args);
+          const u8 = new Uint8Array(memory.buffer);
+          u8.set(bytes, 0);
+          const len = instance.exports.callback(id, 0);
+          const res = fasl_to_js_value(u8.slice(0, len))[0];
+          return res;
+        };
       })
     },
     'standard': {
@@ -748,20 +760,18 @@ var imports = {
     }
 };
 
-const wasmModule
-      = await WebAssembly
-      .instantiate(wasmBuffer, imports)
-      .then(results  => { const { entry, get_bytes, copy_bytes_to_memory } = results.instance.exports;
-                          var result = entry();
-                          // console.log( "Output:")
-                          // console.log( output_string );
-                          // console.log( "Result:")
-                          // console.log( result );
+const wasmModule = await WebAssembly.instantiate(wasmBuffer, imports);
+instance = wasmModule.instance;
+const { entry, get_bytes, copy_bytes_to_memory } = instance.exports;
+var result = entry();
+// console.log( "Output:")
+// console.log( output_string );
+// console.log( "Result:")
+// console.log( result );
 
-                          // console.log( "Result bytes:" )
-                          const bytes  = new Uint8Array(memory.buffer, 0, result);
-                          console.log(new TextDecoder().decode(bytes));
-                        });
+// console.log( "Result bytes:" )
+const bytes  = new Uint8Array(memory.buffer, 0, result);
+console.log(new TextDecoder().decode(bytes));
 
 
 

--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -1061,6 +1061,7 @@
             procedure-arity-includes?
             procedure-arity-mask
             procedure-arity
+            procedure->external
             procedure?
             procedure-rename
             apply


### PR DESCRIPTION
## Summary
- wrap and export `$procedure->external` so procedures can be converted to callable extern values
- provide Racket stub and compiler mapping for `procedure->external`
- support callback creation in Node runtime
- track `procedure->external` in completion list

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b04fe3b4e48322b6a2535c6fd675f5