### PR TITLE
Add addEventListener binding

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -1441,6 +1441,12 @@ var imports = {
         'stop-propagation'() { throw new Error('DOM not available in this environment'); },
         'stop-immediate-propagation'() { throw new Error('DOM not available in this environment'); }
     },
+    // EventTarget
+    'event-target': hasDOM ? {
+        'add-event-listener!': ((target, type, listener) => target.addEventListener(from_fasl(type), listener))
+    } : {
+        'add-event-listener!'() { throw new Error('DOM not available in this environment'); }
+    },
     // Element
     'element': hasDOM ? {
         'append-child!':           ((parent, child)          => parent.appendChild(child)),

--- a/dom.ffi
+++ b/dom.ffi
@@ -731,6 +731,17 @@
   (-> (string) ()))
  
 
+;;; EventTarget
+;;;
+; The various functions in this section are documented here:
+;
+;     https://developer.mozilla.org/en-US/docs/Web/API/EventTarget
+;
+(define-foreign js-add-event-listener!
+  #:module "event-target"
+  #:name   "add-event-listener!"
+  (-> (extern string extern) ()))
+
 ;;; Event
 ;;;
 ; The various functions in this section are documented here:


### PR DESCRIPTION
## Summary
- expose EventTarget.addEventListener through dom.ffi
- implement event-target support in runtime assembler

## Testing
- `raco test test/test-basics.rkt test/test-linear-memory.rkt test/test-callback.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b05a457e588322a8050cdbe495eb8e