### PR TITLE
Use procedure->external for callback example

### DIFF
--- a/test/callback-example.rkt
+++ b/test/callback-example.rkt
@@ -44,7 +44,7 @@
   (set! count (+ count 1))
   (update))
 
-(define id (callback-register on-click))
-(js-eval (string-append "document.getElementById('press-button').addEventListener('click', make_callback("
-                        (number->string id)
-                        "));"))
+(define on-click-host (procedure->external on-click))
+(js-add-event-listener! (js-document-get-element-by-id "press-button")
+                        "click"
+                        on-click-host)


### PR DESCRIPTION
## Summary
- Convert `on-click` handler into a host function via `procedure->external`
- Register the click handler with `js-add-event-listener!` for the button

## Testing
- `raco test test/test-callback.rkt` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b05d73c49c83228027aa8120bf5a69