### PR TITLE
Fix $fasl:s-exp->fasl parens

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -11563,12 +11563,10 @@
                                                                           (then
                                                                            (drop (call $write-byte (global.get $fasl-external) (local.get $out)))
                                                                            (call $fasl:write-u32
-                                                                                 (call $js-register-external
-                                                                                       (struct.get $External $v (ref.cast (ref $External) (local.get $v))))
-                                                                                 (local.get $out)))
-                                                                          (else
-                                                                           (unreachable) ;; unsupported type
-                                                                           )))))))))))))))
+                                                                      (call $js-register-external
+                                                                                      (struct.get $External $v (ref.cast (ref $External) (local.get $v))))
+                                                                                (local.get $out)))
+                                                                          (else (unreachable)))))))))))))))))))) ;; unsupported type
 
          (func $s-exp->fasl/immediate
                (param $i   i32)


### PR DESCRIPTION
## Summary
- fix closing parentheses in `$fasl:s-exp->fasl` to avoid hanging parens

## Testing
- `raco test runtime-wasm.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b063728f60832280434836c0933553