### PR TITLE
Prevent null externs during FASL encoding

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -11564,7 +11564,9 @@
                                                                            (drop (call $write-byte (global.get $fasl-external) (local.get $out)))
                                                                            (call $fasl:write-u32
                                                                                  (call $js-register-external
-                                                                                       (struct.get $External $v (ref.cast (ref $External) (local.get $v))))
+                                                                                       (ref.as_non_null
+                                                                                         (struct.get $External $v
+                                     (ref.cast (ref $External) (local.get $v)))))
                                                                                  (local.get $out)))
                                                                           (else (unreachable)))))))))))))))))) ;; unsupported type
          


### PR DESCRIPTION
## Summary
- guard `js-register-external` with `ref.as_non_null` when encoding `External` values

## Testing
- `raco test test/test-linear-memory.rkt` *(command not found: raco)*
- `apt-get update` *(403 for repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b067fb9ec4832288800281610769be