### PR TITLE
Update callback example to mutate text content

### DIFF
--- a/test/callback-example.rkt
+++ b/test/callback-example.rkt
@@ -34,11 +34,11 @@
 
 (define (update)
   (define msg (js-get-element-by-id "message"))
-  (js-replace-children! msg
-                         (js-create-text-node
-                          (string-append "You have pressed the button "
-                                         (number->string count)
-                                         " times"))))
+  (js-set-attribute! msg
+                     "textContent"
+                     (string-append "You have pressed the button "
+                                    (number->string count)
+                                    " times")))
 
 (define (on-click _event)
   (set! count (+ count 1))


### PR DESCRIPTION
## Summary
- Update callback example to modify existing message text via `textContent` instead of creating new text nodes

## Testing
- `raco test test/callback-example.rkt` *(fails: raco: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b06b2c0ee0832283da3efe22462a51