### PR TITLE
Add standard binding for JS property assignment

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -509,6 +509,7 @@ var imports = {
       'encode-uri-component':      ((s) => encodeURIComponent(from_fasl(s))),
       'escape':                    ((s) => escape(from_fasl(s))),
       'unescape':                  ((s) => unescape(from_fasl(s))),
+      'set-property!':             ((obj, key, val) => { obj[from_fasl(key)] = from_fasl(val); }),
       'object':                    (() => Object),
       'function':                  (() => Function),
       'boolean':                   (() => Boolean),

--- a/standard.ffi
+++ b/standard.ffi
@@ -90,6 +90,11 @@
   #:name   "unescape"
   (-> (string) (extern)))
 
+(define-foreign js-set-property!
+  #:module "standard"
+  #:name   "set-property!"
+  (-> (extern value value) ()))
+
 ;;;
 ;;; Fundamental objects
 ;;;


### PR DESCRIPTION
## Summary
- Add `set-property!` binding to runtime assembler for setting object properties
- Expose new binding via `js-set-property!` in standard FFI

## Testing
- `raco test ./test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b08692cf808322ad51b9b5929c1fcf