### PR TITLE
Log closure invocation details

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -765,6 +765,10 @@
                           (i32.shr_s (i31.get_s (local.get $arity-i31)) (i32.const 1)))
                ;; Step 3: get argument count
                (local.set $arg-count (array.len (local.get $args)))
+               ;; Debug: log closure, argument count, and expected arity
+               (drop (call $js-log (local.get $clos)))
+               (drop (call $js-log (call $i32->string (local.get $arg-count))))
+               (drop (call $js-log (call $i32->string (local.get $arity-i32))))
                ;; Step 4: check arity match
                (if (i32.eqz
                     (call $procedure-arity-includes?/checked/i32


### PR DESCRIPTION
## Summary
- Add js-log debug output in `$invoke-closure` to trace invoked closure and its argument and arity counts

## Testing
- `raco test runtime-wasm.rkt` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bdec15e48322b2ef7be27e698e4a