### PR TITLE
Add unsafe-struct-ref primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -571,6 +571,7 @@
 
   unsafe-car
   unsafe-cdr
+  unsafe-struct-ref
   unsafe-vector*-length
   unsafe-vector*-set!
 

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -12123,6 +12123,17 @@
          (func $unsafe-cdr (type $Prim1) (param $v (ref eq)) (result (ref eq))
                (struct.get $Pair $d (ref.cast (ref $Pair) (local.get $v))))
 
+         (func $unsafe-struct-ref (type $Prim2)
+               (param $v (ref eq))
+               (param $k (ref eq))
+               (result (ref eq))
+               (array.get $Array
+                          (struct.get $Struct $fields
+                                      (ref.cast (ref $Struct) (local.get $v)))
+                          (i32.shr_s (i31.get_s (ref.cast (ref i31)
+                                                          (local.get $k)))
+                                     (i32.const 1))))
+
          ;; Note the `unsafe-vector*-...` variants do not work on impersonators.
          ;; (the `unsafe-vector-...` variants do)
          (func $unsafe-vector*-length (type $Prim1) (param $v (ref eq)) (result (ref eq))

--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -1049,6 +1049,7 @@
             unsafe-vector*-length
             unsafe-cdr
             unsafe-car
+            unsafe-struct-ref
             unsafe-fx<
             unsafe-fx=
             unsafe-fl/


### PR DESCRIPTION
## Summary
- implement `unsafe-struct-ref` runtime function
- expose `unsafe-struct-ref` to compiler and completion list

## Testing
- `racket test/completion.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b178aed1e08322ac654c52cc00392c