### PR TITLE
Implement unsafe-struct-set! primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -573,6 +573,7 @@
   unsafe-cdr
   unsafe-vector*-length
   unsafe-vector*-set!
+  unsafe-struct-set!
 
   namespace?
   make-empty-namespace

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -12184,9 +12184,9 @@
                (param $idx (ref eq))
                (param $val (ref eq))
                (result     (ref eq))
-               
+
                (array.set $Array
-                          (struct.get $Vector $arr 
+                          (struct.get $Vector $arr
                                       (ref.cast (ref $Vector) (local.get $vec)))
                           (i32.shr_s (i31.get_s (ref.cast (ref i31)
                                                           (local.get $idx)))
@@ -12194,10 +12194,25 @@
                           (local.get $val))
                (global.get $void))
 
-         ;; 17.4 Unsafe Extflonum Operations
-         ;; 17.5 Unsafe Impersonators and Chaperones
-         ;; 17.6 Unsafe Assertions
-         ;; 17.7 Unsafe Undefined
+        (func $unsafe-struct-set!
+              (param $struct (ref eq))
+              (param $idx    (ref eq))
+              (param $val    (ref eq))
+              (result        (ref eq))
+
+              (array.set $Array
+                         (struct.get $Struct $fields
+                                     (ref.cast (ref $Struct) (local.get $struct)))
+                         (i32.shr_s (i31.get_s (ref.cast (ref i31)
+                                                         (local.get $idx)))
+                                    (i32.const 1))
+                         (local.get $val))
+              (global.get $void))
+
+        ;; 17.4 Unsafe Extflonum Operations
+        ;; 17.5 Unsafe Impersonators and Chaperones
+        ;; 17.6 Unsafe Assertions
+        ;; 17.7 Unsafe Undefined
          
          
          

--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -1045,6 +1045,7 @@
             namespace-variable-value-simple
             make-empty-namespace
             namespace?
+            unsafe-struct-set!
             unsafe-vector*-set!
             unsafe-vector*-length
             unsafe-cdr


### PR DESCRIPTION
## Summary
- add `unsafe-struct-set!` runtime primitive for mutating struct fields
- expose `unsafe-struct-set!` to compiler and completion metadata

## Testing
- `raco test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1797263c8832290182a3edd7efb5c