### PR TITLE
Add Prim3 primitive type and dispatch

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -322,7 +322,9 @@
           (type $Prim0    (func                                   (result (ref eq))))
           (type $Prim1    (func (param (ref eq))                  (result (ref eq))))
           (type $Prim2    (func (param (ref eq)) (param (ref eq)) (result (ref eq))))
-          
+          (type $Prim3    (func (param (ref eq)) (param (ref eq)) (param (ref eq))
+                                (result (ref eq))))
+
           (type $Prim>=0  (func (param (ref eq))      ;; list of args
                                 (result (ref eq))))
           (type $Prim>=1  (func (param (ref eq))      ;; first arg
@@ -828,8 +830,8 @@
               (unreachable))
         
         ;; Shape codes:
-        ;;   0: exact 0     1: exact 1     2: exact 2     3: exact >=3
-        ;;   4: at least 0  5: at least 1  6: at least 2  7: at least >=3
+        ;;   0: exact 0     1: exact 1     2: exact 2     3: exact 3     4: exact >=4
+        ;;   5: at least 0  6: at least 1  7: at least 2  8: at least >=3
         (func $primitive-invoke (type $ProcedureInvoker)
               (param $proc (ref $Procedure))
               (param $args (ref $Args))
@@ -878,18 +880,18 @@
               ;; Compute shape (and k for "at least k")
               (if (i32.ge_s (local.get $arity) (i32.const 0))
                   (then
-                   ;; exact: shape = min(arity, 3)
+                   ;; exact: shape = min(arity, 4)
                    (local.set $shape (local.get $arity))
-                   (if (i32.gt_u (local.get $shape) (i32.const 3))
-                       (then (local.set $shape (i32.const 3)))))
+                   (if (i32.gt_u (local.get $shape) (i32.const 4))
+                       (then (local.set $shape (i32.const 4)))))
                   (else
-                   ;; at least: k = -arity - 1; shape = 4 + min(k, 3)
+                   ;; at least: k = -arity - 1; shape = 5 + min(k, 3)
                    (local.set $k
                               (i32.sub (i32.const -1) (local.get $arity)))
                    (local.set $shape (local.get $k))
                    (if (i32.gt_u (local.get $shape) (i32.const 3))
                        (then (local.set $shape (i32.const 3))))
-                   (local.set $shape (i32.add (i32.const 4) (local.get $shape)))))
+                   (local.set $shape (i32.add (i32.const 5) (local.get $shape)))))
 
               ;; Debug: log argc, arity, shape
               ;; (drop (call $js-log (call $i32->string (local.get $argc))))
@@ -912,64 +914,82 @@
 
               ;; br_table dispatch by shape
               (block $default
-                (block $L7
-                  (block $L6
-                    (block $L5
-                      (block $L4
-                        (block $L3
-                          (block $L2
-                            (block $L1
-                              (block $L0
-                                (br_table $L0 $L1 $L2 $L3 $L4 $L5 $L6 $L7 $default (local.get $shape))
-                              ) ;; end $L0
-                              ;; shape 0: exact 0
-                              #;(drop (call $js-log (call $i32->string (i32.const 0))))
-                              (if (i32.eqz (local.get $argc))
+                (block $L8
+                  (block $L7
+                    (block $L6
+                      (block $L5
+                        (block $L4
+                          (block $L3
+                            (block $L2
+                              (block $L1
+                                (block $L0
+                                  (br_table $L0 $L1 $L2 $L3 $L4 $L5 $L6 $L7 $L8 $default (local.get $shape))
+                                ) ;; end $L0
+                                ;; shape 0: exact 0
+                                #;(drop (call $js-log (call $i32->string (i32.const 0))))
+                                (if (i32.eqz (local.get $argc))
+                                    (then
+                                     (if (ref.test (ref $Prim0) (local.get $code))
+                                         (then
+                                          (return_call_ref $Prim0
+                                                           (ref.cast (ref $Prim0) (local.get $code))))
+                                         (else
+                                          (return (call $raise-code-type-mismatch (local.get $pproc)))))
+                                    (else
+                                     (return (call $primitive-invoke:raise-arity-error
+                                                   (local.get $pproc) (local.get $argc)))))
+                              )) ;; end $L1
+                              ;; shape 1: exact 1
+                              #;(drop (call $js-log (call $i32->string (i32.const 1))))
+                              (if (i32.eq (local.get $argc) (i32.const 1))
                                   (then
-                                   (if (ref.test (ref $Prim0) (local.get $code))
+                                   (if (ref.test (ref $Prim1) (local.get $code))
                                        (then
-                                        (return_call_ref $Prim0
-                                                         (ref.cast (ref $Prim0) (local.get $code))))
+                                        (return_call_ref $Prim1
+                                                         (local.get $a0)
+                                                         (ref.cast (ref $Prim1) (local.get $code))))
                                        (else
                                         (return (call $raise-code-type-mismatch (local.get $pproc)))))
                                   (else
                                    (return (call $primitive-invoke:raise-arity-error
                                                  (local.get $pproc) (local.get $argc)))))
-                            )) ;; end $L1
-                            ;; shape 1: exact 1
-                            #;(drop (call $js-log (call $i32->string (i32.const 1))))
-                            (if (i32.eq (local.get $argc) (i32.const 1))
+                            )) ;; end $L2
+                            ;; shape 2: exact 2
+                            #;(drop (call $js-log (call $i32->string (i32.const 2))))
+                            (if (i32.eq (local.get $argc) (i32.const 2))
                                 (then
-                                 (if (ref.test (ref $Prim1) (local.get $code))
+                                 (if (ref.test (ref $Prim2) (local.get $code))
                                      (then
-                                      (return_call_ref $Prim1
+                                      (return_call_ref $Prim2
                                                        (local.get $a0)
-                                                       (ref.cast (ref $Prim1) (local.get $code))))
+                                                       (local.get $a1)
+                                                       (ref.cast (ref $Prim2) (local.get $code))))
                                      (else
                                       (return (call $raise-code-type-mismatch (local.get $pproc)))))
                                 (else
                                  (return (call $primitive-invoke:raise-arity-error
                                                (local.get $pproc) (local.get $argc)))))
-                          )) ;; end $L2
-                          ;; shape 2: exact 2
-                          #;(drop (call $js-log (call $i32->string (i32.const 2))))
-                          (if (i32.eq (local.get $argc) (i32.const 2))
+                          )) ;; end $L3
+                          ;; shape 3: exact 3
+                          #;(drop (call $js-log (call $i32->string (i32.const 3))))
+                          (if (i32.eq (local.get $argc) (i32.const 3))
                               (then
-                               (if (ref.test (ref $Prim2) (local.get $code))
+                               (if (ref.test (ref $Prim3) (local.get $code))
                                    (then
-                                    (return_call_ref $Prim2
+                                    (return_call_ref $Prim3
                                                      (local.get $a0)
                                                      (local.get $a1)
-                                                     (ref.cast (ref $Prim2) (local.get $code))))
+                                                     (local.get $a2)
+                                                     (ref.cast (ref $Prim3) (local.get $code))))
                                    (else
                                     (return (call $raise-code-type-mismatch (local.get $pproc)))))
                               (else
                                (return (call $primitive-invoke:raise-arity-error
                                              (local.get $pproc) (local.get $argc)))))
-                        )) ;; end $L3
-                        ;; shape 3: exact >=3
-                        #;(drop (call $js-log (call $i32->string (i32.const 3))))
-                        (if (i32.ge_u (local.get $argc) (i32.const 3))
+                        )) ;; end $L4
+                        ;; shape 4: exact >=4
+                        #;(drop (call $js-log (call $i32->string (i32.const 4))))
+                        (if (i32.ge_u (local.get $argc) (i32.const 4))
                             (then
                              (if (i32.eq (local.get $argc) (local.get $arity))
                                  (then
@@ -989,19 +1009,19 @@
                             (else
                              (return (call $primitive-invoke:raise-arity-error
                                            (local.get $pproc) (local.get $argc)))))
-                      )) ;; end $L4
-                      ;; shape 4: at least 0
-                      #;(drop (call $js-log (call $i32->string (i32.const 4))))
+                      )) ;; end $L5
+                      ;; shape 5: at least 0
+                      #;(drop (call $js-log (call $i32->string (i32.const 5))))
                       (if (ref.test (ref $Prim>=0) (local.get $code))
                           (then
                            (return_call_ref $Prim>=0
                                             (local.get $args)
                                             (ref.cast (ref $Prim>=0) (local.get $code))))
                           (else
-                           (return (call $raise-code-type-mismatch (local.get $pproc))))
-                    )) ;; end $L5
-                    ;; shape 5: at least 1
-                    #;(drop (call $js-log (call $i32->string (i32.const 5))))
+                           (return (call $raise-code-type-mismatch (local.get $pproc)))))
+                    )) ;; end $L6
+                    ;; shape 6: at least 1
+                    #;(drop (call $js-log (call $i32->string (i32.const 6))))
                     (if (i32.ge_u (local.get $argc) (i32.const 1))
                         (then
                          (if (ref.test (ref $Prim>=1) (local.get $code))
@@ -1015,9 +1035,9 @@
                         (else
                          (return (call $primitive-invoke:raise-arity-error
                                        (local.get $pproc) (local.get $argc)))))
-                  )) ;; end $L6
-                  ;; shape 6: at least 2
-                  #;(drop (call $js-log (call $i32->string (i32.const 6))))
+                  )) ;; end $L7
+                  ;; shape 7: at least 2
+                  #;(drop (call $js-log (call $i32->string (i32.const 7))))
                   (if (i32.ge_u (local.get $argc) (i32.const 2))
                       (then
                        (if (ref.test (ref $Prim>=2) (local.get $code))
@@ -1032,9 +1052,9 @@
                       (else
                        (return (call $primitive-invoke:raise-arity-error
                                      (local.get $pproc) (local.get $argc)))))
-                )) ;; end $L7
-                ;; shape 7: at least >=3
-                #;(drop (call $js-log (call $i32->string (i32.const 7))))
+                )) ;; end $L8
+                ;; shape 8: at least >=3
+                #;(drop (call $js-log (call $i32->string (i32.const 8))))
                 (if (i32.ge_u (local.get $argc) (i32.const 3))
                     (then
                      (if (ref.test (ref $Prim>=3) (local.get $code))
@@ -1051,7 +1071,7 @@
                      (return (call $primitive-invoke:raise-arity-error
                                    (local.get $pproc) (local.get $argc)))))
               )) ;; end $default
-              #;(drop (call $js-log (call $i32->string (i32.const 8))))
+              #;(drop (call $js-log (call $i32->string (i32.const 9))))
               (unreachable))
 
         (func $repack-arguments


### PR DESCRIPTION
## Summary
- add $Prim3 function type to runtime
- extend primitive invocation dispatch to handle exact three-argument primitives

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found: raco)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a4218cf08322bd18582ab2adad80