### PR TITLE
Support optional arguments in string-copy! primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3033,6 +3033,7 @@
           (inline-prim/optional sym ae1 1 2)]
          [(fasl->s-exp)                (inline-prim/fixed sym ae1 1)]
          [(vector-copy!)               (inline-prim/optional sym ae1 3 5)]
+         [(string-copy!)               (inline-prim/optional sym ae1 3 5)]
          [(make-vector)                (inline-prim/optional sym ae1 1 2)]
          [(make-string)                (inline-prim/optional sym ae1 1 2)]
          [(substring)                  (inline-prim/optional sym ae1 2 3)]


### PR DESCRIPTION
## Summary
- add function types `Prim4` and `Prim5`
- allow `string-copy!` to accept optional start/end and expose it as a typed primitive
- inline `string-copy!` calls with optional arguments in the compiler

## Testing
- ⚠️ `raco test test/test-basics.rkt test/completion.rkt` *(command not found: raco)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b7eb5d0c832282d0094f6561b8f7