### PR TITLE
Handle optional hash-ref failure result

### DIFF
--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -733,12 +733,15 @@
                 (hash-set! h 'a 1)
                 (equal? (hash-ref h 'a) 1)))
 
-        ;; (list "hash-ref"
-        ;;       (let ([h (make-hasheq)])
-        ;;         (hash-set! h 'a 1)
-        ;;         (and (equal? (hash-ref h 'a) 1)
-        ;;              (equal? (hash-ref h 'b 2) 2)
-        ;;              (equal? (hash-ref h 'b (lambda () 3)) 3))))
+        (list "hash-ref"
+              (let ([h (make-hasheq)])
+                (hash-set! h 'a 1)
+                (and (equal? (hash-ref h 'a) 1)
+                     (equal? (hash-ref h 'b 2) 2)
+                     (equal? (hash-ref h 'b (lambda () 3)) 3)
+                     (equal? (with-handlers ([exn:fail? (λ (_) 'no)])
+                               (hash-ref h 'c))
+                              'no))))
 
         ;; (list "hash-remove!"
         ;;       (let ([h (make-hasheq)])


### PR DESCRIPTION
## Summary
- Support optional failure-result for `$hash-ref` so missing keys can trigger custom thunks or return provided values.
- Implement runtime error raising when a key is absent and no failure-result is supplied.
- Expand basic tests to cover `hash-ref` with default values, thunks, and missing keys.

## Testing
- `racket test/test-basics.rkt` *(command failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f901459c83228ed94dcff7c1f3cb