### PR TITLE
Implement flonum primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -482,7 +482,9 @@
 
   flonum?
   fl+ fl- fl* fl/
-  fl= fl< fl> fl<= fl>= flround flsin flcos fltan flsqrt
+  fl= fl< fl> fl<= fl>=
+  flabs flround flfloor flceiling fltruncate flsingle
+  flsin flcos fltan flasin flacos flatan fllog flexp flsqrt
 
   byte?
 
@@ -573,6 +575,9 @@
   ;; 17. Unsafe Operations
   unsafe-fx+
   unsafe-fl/
+  unsafe-flabs unsafe-flround unsafe-flfloor unsafe-flceiling unsafe-fltruncate
+  unsafe-flsingle unsafe-flsin unsafe-flcos unsafe-fltan unsafe-flasin
+  unsafe-flacos unsafe-flatan unsafe-fllog unsafe-flexp unsafe-flsqrt
 
   unsafe-fx=
   unsafe-fx<

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -45,7 +45,9 @@
  inexact->exact round sqrt number->string
  + - * / = < > <= >= zero? positive? negative? add1 sub1
  fixnum? fxzero? fx+ fx- fx* fx= fx> fx< fx<= fx>= fxquotient unsafe-fxquotient
- flonum? fl+ fl- fl* fl/ fl= fl< fl> fl<= fl>= flround flsin flcos fltan flsqrt
+ flonum? fl+ fl- fl* fl/ fl= fl< fl> fl<= fl>=
+ flabs flround flfloor flceiling fltruncate flsingle
+ flsin flcos fltan flasin flacos flatan fllog flexp flsqrt
  byte? 
 
  ;; Fixnum
@@ -82,7 +84,9 @@
  fx->fl
  fl->fx
 
- inexact->exact round sqrt flround flsin flcos fltan flsqrt
+ inexact->exact round sqrt
+ flabs flround flfloor flceiling fltruncate flsingle
+ flsin flcos fltan flasin flacos flatan fllog flexp flsqrt
 
  
  ;; 4.4 Strings
@@ -265,7 +269,11 @@
  namespace-set-variable-value! namespace-undefine-variable!
 
  ;; 17. Unsafe Operations
- unsafe-fx+ unsafe-fl/ unsafe-fx= unsafe-fx< unsafe-car unsafe-cdr
+ unsafe-fx+ unsafe-fl/
+ unsafe-flabs unsafe-flround unsafe-flfloor unsafe-flceiling unsafe-fltruncate
+ unsafe-flsingle unsafe-flsin unsafe-flcos unsafe-fltan unsafe-flasin
+ unsafe-flacos unsafe-flatan unsafe-fllog unsafe-flexp unsafe-flsqrt
+ unsafe-fx= unsafe-fx< unsafe-car unsafe-cdr
  unsafe-struct-ref unsafe-vector*-length unsafe-vector*-set! unsafe-struct-set!
  
 


### PR DESCRIPTION
## Summary
- Add missing flonum primitives and unsafe counterparts
- Generate flonum unary operations in runtime using loops
- Import additional JavaScript math functions

## Testing
- `raco test test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b9476b883229cf5d334ec3d1a22