### PR TITLE
Track flonum primitives

### DIFF
--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -1018,6 +1018,52 @@
       prop:checked-procedure
       prop:procedure
     )
+    (racket/flonum
+      fl+
+      fl-
+      fl*
+      fl/
+      flabs
+      fl=
+      fl<
+      fl>
+      fl<=
+      fl>=
+      flmin
+      flmax
+      flround
+      flfloor
+      flceiling
+      fltruncate
+      flsingle
+      flbit-field
+      flsin
+      flcos
+      fltan
+      flasin
+      flacos
+      flatan
+      fllog
+      flexp
+      flsqrt
+      flexpt
+      ->fl
+      fl->exact-integer
+      make-flrectangular
+      flreal-part
+      flimag-part
+      flrandom
+      flvector?
+      flvector
+      make-flvector
+      flvector-length
+      flvector-ref
+      flvector-set!
+      flvector-copy
+      in-flvector
+      shared-flvector
+      make-shared-flvector
+    )
     (void
       void
       void?


### PR DESCRIPTION
## Summary
- list racket/flonum primitives in completion data

## Testing
- `raco test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35b2fe9248322bb8103f1a9879819