### PR TITLE
Add racket/fixnum section

### DIFF
--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -269,7 +269,53 @@
       vector->pseudo-random-generator!
       zero?
       )
-    
+
+    (racket/fixnum
+      fixnum-for-every-system?
+      fl->fx
+      fx*
+      fx*/wraparound
+      fx+
+      fx+/wraparound
+      fx-
+      fx-/wraparound
+      fx->fl
+      fx<
+      fx<=
+      fx=
+      fx>
+      fx>=
+      fxabs
+      fxand
+      fxior
+      fxlshift
+      fxlshift/wraparound
+      fxmax
+      fxmin
+      fxmodulo
+      fxnot
+      fxpopcount
+      fxpopcount16
+      fxpopcount32
+      fxquotient
+      fxremainder
+      fxrshift
+      fxrshift/logical
+      fxvector
+      fxvector-copy
+      fxvector-length
+      fxvector-ref
+      fxvector-set!
+      fxvector?
+      fxxor
+      in-fxvector
+      make-fxvector
+      make-shared-fxvector
+      most-negative-fixnum
+      most-positive-fixnum
+      shared-fxvector
+      )
+
     (strings
       build-string
       list->string


### PR DESCRIPTION
## Summary
- Track fixnum-specific operations by adding a `racket/fixnum` section to completion.rkt.
- Include arithmetic, bitwise, wraparound, vector, and range helpers.

## Testing
- `racket -t ../webracket.rkt -- --ffi ../standard.ffi --ffi ../dom.ffi -b completion.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35b3f3ec48322bb72fd279871d79c