### PR TITLE
Handle optional argument for fx-/wraparound

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -3333,10 +3333,34 @@
                (ref.i31 (i32.add (i31.get_s (ref.cast i31ref (local.get $x)))
                                  (i31.get_s (ref.cast i31ref (local.get $y))))))
 
-         (func $fx-/wraparound (type $Prim2)
-               (param $x (ref eq)) (param $y (ref eq)) (result (ref eq))
-               (ref.i31 (i32.sub (i31.get_s (ref.cast i31ref (local.get $x)))
-                                 (i31.get_s (ref.cast i31ref (local.get $y))))))
+        (func $fx-/wraparound (type $Prim>=1)
+               (param $a1   (ref eq))  ;; either `a` or `b`
+               (param $rest (ref eq))  ;; remaining args
+               (result      (ref eq))
+
+               (local $a    (ref eq))
+               (local $b    (ref eq))
+               (local $node (ref $Pair))
+
+               ;; Determine arguments based on rest list
+               (if (ref.eq (local.get $rest) (global.get $null))
+                   ;; Only one argument provided: treat as (0 - a1)
+                   (then (local.set $a ,(Imm 0))
+                         (local.set $b (local.get $a1)))
+                   ;; Otherwise expect exactly one more argument
+                   (else (if (ref.test (ref $Pair) (local.get $rest))
+                              (then (local.set $node (ref.cast (ref $Pair) (local.get $rest)))
+                                    (local.set $a    (local.get $a1))
+                                    (local.set $b    (struct.get $Pair $a (local.get $node)))
+                                    ;; Ensure no extra arguments
+                                    (if (ref.eq (struct.get $Pair $d (local.get $node))
+                                                (global.get $null))
+                                        (nop)
+                                        (call $raise-arity-error:exactly)))
+                              (call $raise-arity-error:exactly))))
+
+               (ref.i31 (i32.sub (i31.get_s (ref.cast i31ref (local.get $a)))
+                                 (i31.get_s (ref.cast i31ref (local.get $b))))))
 
          (func $fx*/wraparound (type $Prim2)
                (param $x (ref eq)) (param $y (ref eq)) (result (ref eq))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -174,7 +174,10 @@
               (and (equal? (number->string 42) "42")
                    (equal? (number->string 16 16) "10")
                    (equal? (number->string 1.25) "1.25")
-                   (equal? (number->string 1.0) "1.0")))))
+                   (equal? (number->string 1.0) "1.0")))
+        (list "fx-/wraparound"
+              (and (equal? (fx-/wraparound 10 3) 7)
+                   (equal? (fx-/wraparound 3) -3)))))
 
  (list "4.4 Strings"
        (list


### PR DESCRIPTION
## Summary
- Support optional first argument for `fx-/wraparound` by reimplementing it as a `$Prim>=1` primitive.
- Add a basic test ensuring `fx-/wraparound` works with one or two arguments.

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b36a99f8fc83228b3fca82d54e0d16