### PR TITLE
Add fixnum limit primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -477,6 +477,7 @@
   fxpopcount fxpopcount16 fxpopcount32
   fx+/wraparound fx-/wraparound fx*/wraparound fxlshift/wraparound
   fxrshift/logical
+  most-positive-fixnum most-negative-fixnum
 
   ; fx->fl fl->fx
   ; fixnum-for-every-system?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -11,7 +11,8 @@
          racket/string
          racket/symbol
          racket/vector
-         racket/unsafe/ops)
+         racket/unsafe/ops
+         (prefix-in imm: "immediates.rkt"))
 
 ;; The primitives are 
 
@@ -83,6 +84,8 @@
 
  fx->fl
  fl->fx
+ most-positive-fixnum
+ most-negative-fixnum
 
  inexact->exact round sqrt
  flabs flround flfloor flceiling fltruncate flsingle
@@ -316,6 +319,12 @@
 (define (fxzero? x)
   (and (fixnum? x)
        (zero? x)))
+
+(define (most-positive-fixnum)
+  imm:most-positive-fixnum)
+
+(define (most-negative-fixnum)
+  imm:most-negative-fixnum)
 
 (define (string-take s n)
   (define l (string-length s))

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -3385,6 +3385,12 @@
                (ref.i31 (i32.shr_u (i31.get_u (ref.cast i31ref (local.get $x)))
                                    ,(Half `(i31.get_u (ref.cast i31ref (local.get $y)))))))
 
+         (func $most-positive-fixnum (type $Prim0) (result (ref eq))
+               ,(Imm most-positive-fixnum))
+
+         (func $most-negative-fixnum (type $Prim0) (result (ref eq))
+               ,(Imm most-negative-fixnum))
+
          (func $fx= (type $Prim2) (param $v1 (ref eq)) (param $v2 (ref eq)) (result (ref eq))
                (if (result (ref eq))
                    (ref.eq (call $fixnum? (local.get $v1))


### PR DESCRIPTION
## Summary
- expose fixnum range helpers most-positive-fixnum and most-negative-fixnum
- wire primitives through compiler and WebAssembly runtime

## Testing
- `raco test test` *(fails: command not found)*
- `racket --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b37224c998832290c61f44772cf1dd