### PR TITLE
Add variadic fixnum comparisons

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3072,7 +3072,19 @@
 
          [(hash-ref)                   (inline-prim/optional sym ae1 2 3)]
          [(fx-/wraparound)             (inline-prim/variadic sym ae1 1 1)] ; actual arity: 1,2
-         
+
+        [(fx= fx< fx> fx<= fx>=)
+          ; variadic, at least one argument
+          (define n   (length ae1))
+          (when (< n 1) (error 'primapp "too few arguments: ~a" sym))
+          (define aes  (AExpr* ae1))
+          (define $cmp   ($ sym))
+          (define $cmp/2 ($ (string->symbol (~a sym "/2"))))
+          (case n
+            [(1) `(call ,$cmp ,(first aes) (global.get $null))]
+            [(2) `(call ,$cmp/2 ,@aes)]
+            [else `(call ,$cmp ,(first aes) ,(build-rest-args (rest aes)))])]
+
         [(char=? char<? char<=? char>? char>=?
                  char-ci=? char-ci<? char-ci<=? char-ci>? char-ci>=?)
           ; variadic, at least one argument

--- a/docs/fixnums.scrbl
+++ b/docs/fixnums.scrbl
@@ -140,11 +140,11 @@ illustrating that logical right-shift results are platform-dependent.
 
 
 @deftogether[(
-@defproc[(fx=   [a fixnum?] [b fixnum?] ...) boolean?]
-@defproc[(fx<   [a fixnum?] [b fixnum?] ...) boolean?]
-@defproc[(fx>   [a fixnum?] [b fixnum?] ...) boolean?]
-@defproc[(fx<=  [a fixnum?] [b fixnum?] ...) boolean?]
-@defproc[(fx>=  [a fixnum?] [b fixnum?] ...) boolean?]
+@defproc[(fx=   [a fixnum?] ...+) boolean?]
+@defproc[(fx<   [a fixnum?] ...+) boolean?]
+@defproc[(fx>   [a fixnum?] ...+) boolean?]
+@defproc[(fx<=  [a fixnum?] ...+) boolean?]
+@defproc[(fx>=  [a fixnum?] ...+) boolean?]
 @defproc[(fxmin [a fixnum?] [b fixnum?] ...) fixnum?]
 @defproc[(fxmax [a fixnum?] [b fixnum?] ...) fixnum?]
 )]{

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -1,7 +1,12 @@
 #lang racket/base
-(require racket/bool
+ (require racket/bool
          racket/fasl
-         racket/fixnum
+         (rename-in racket/fixnum
+                    [fx=  racket:fx=]
+                    [fx>  racket:fx>]
+                    [fx<  racket:fx<]
+                    [fx<= racket:fx<=]
+                    [fx>= racket:fx>=])
          racket/flonum
          racket/hash
          racket/keyword
@@ -325,6 +330,81 @@
 
 (define (most-negative-fixnum)
   imm:most-negative-fixnum)
+
+(define (fx=/2 a b)
+  (racket:fx= a b))
+
+(define (fx>/2 a b)
+  (racket:fx> a b))
+
+(define (fx</2 a b)
+  (racket:fx< a b))
+
+(define (fx<=/2 a b)
+  (racket:fx<= a b))
+
+(define (fx>=/2 a b)
+  (racket:fx>= a b))
+
+(define (fx= x . xs)
+  (unless (fixnum? x)
+    (raise-argument-error 'fx= "fixnum?" x))
+  (let loop ([prev x] [rest xs])
+    (cond
+      [(null? rest) #t]
+      [else (define y (car rest))
+            (unless (fixnum? y)
+              (raise-argument-error 'fx= "fixnum?" y))
+            (and (fx=/2 prev y)
+                 (loop y (cdr rest)))])))
+
+(define (fx> x . xs)
+  (unless (fixnum? x)
+    (raise-argument-error 'fx> "fixnum?" x))
+  (let loop ([prev x] [rest xs])
+    (cond
+      [(null? rest) #t]
+      [else (define y (car rest))
+            (unless (fixnum? y)
+              (raise-argument-error 'fx> "fixnum?" y))
+            (and (fx>/2 prev y)
+                 (loop y (cdr rest)))])))
+
+(define (fx< x . xs)
+  (unless (fixnum? x)
+    (raise-argument-error 'fx< "fixnum?" x))
+  (let loop ([prev x] [rest xs])
+    (cond
+      [(null? rest) #t]
+      [else (define y (car rest))
+            (unless (fixnum? y)
+              (raise-argument-error 'fx< "fixnum?" y))
+            (and (fx</2 prev y)
+                 (loop y (cdr rest)))])))
+
+(define (fx<= x . xs)
+  (unless (fixnum? x)
+    (raise-argument-error 'fx<= "fixnum?" x))
+  (let loop ([prev x] [rest xs])
+    (cond
+      [(null? rest) #t]
+      [else (define y (car rest))
+            (unless (fixnum? y)
+              (raise-argument-error 'fx<= "fixnum?" y))
+            (and (fx<=/2 prev y)
+                 (loop y (cdr rest)))])))
+
+(define (fx>= x . xs)
+  (unless (fixnum? x)
+    (raise-argument-error 'fx>= "fixnum?" x))
+  (let loop ([prev x] [rest xs])
+    (cond
+      [(null? rest) #t]
+      [else (define y (car rest))
+            (unless (fixnum? y)
+              (raise-argument-error 'fx>= "fixnum?" y))
+            (and (fx>=/2 prev y)
+                 (loop y (cdr rest)))])))
 
 (define (string-take s n)
   (define l (string-length s))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -273,21 +273,26 @@
                     (equal? (fx- 5 1 1) 3))
               (list "fx*"
                     (equal? (fx* 2 3 4) 24))
-              #;(list "fx="
-                    (and (equal? (fx= 1 1 1) #t)
+              (list "fx="
+                    (and (equal? (fx= 1) #t)
+                         (equal? (fx= 1 1 1) #t)
                          (equal? (fx= 1 2) #f)))
-              ;; (list "fx>"
-              ;;       (and (equal? (fx> 3 2 1) #t)
-              ;;            (equal? (fx> 2 2) #f)))
-              ;; (list "fx<"
-              ;;       (and (equal? (fx< 1 2 3) #t)
-              ;;            (equal? (fx< 2 2) #f)))
-              ;; (list "fx<="
-              ;;       (and (equal? (fx<= 1 1 2) #t)
-              ;;            (equal? (fx<= 2 1) #f)))
-              ;; (list "fx>="
-              ;;       (and (equal? (fx>= 2 2 1) #t)
-              ;;            (equal? (fx>= 1 2) #f)))
+              (list "fx>"
+                    (and (equal? (fx> 3) #t)
+                         (equal? (fx> 3 2 1) #t)
+                         (equal? (fx> 2 2) #f)))
+              (list "fx<"
+                    (and (equal? (fx< 1) #t)
+                         (equal? (fx< 1 2 3) #t)
+                         (equal? (fx< 2 2) #f)))
+              (list "fx<="
+                    (and (equal? (fx<= 1) #t)
+                         (equal? (fx<= 1 1 2) #t)
+                         (equal? (fx<= 2 1) #f)))
+              (list "fx>="
+                    (and (equal? (fx>= 2) #t)
+                         (equal? (fx>= 2 2 1) #t)
+                         (equal? (fx>= 1 2) #f)))
               
               (list "fxquotient"
                     (equal? (fxquotient 13 4) 3))


### PR DESCRIPTION
## Summary
- allow `fx=`, `fx<`, `fx>`, `fx<=`, and `fx>=` to accept one or more arguments
- add specialized `fx=/2`, `fx</2`, `fx>/2`, `fx<=/2`, and `fx>=/2` helpers for two-argument comparison
- update documentation and basic tests for the new variadic behavior

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b377eb3d208322b4cf42229f0943fa