### PR TITLE
Add generic numeric primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -464,7 +464,7 @@
   exact? exact-integer?
   exact-nonnegative-integer?
   exact-positive-integer?
-  inexact->exact round sqrt sin cos tan asin acos atan
+  inexact->exact abs round floor ceiling truncate sqrt sin cos tan asin acos atan
 
   fixnum? fxzero?
   fx+ fx- fx*

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -43,7 +43,7 @@
  ;; 4.3 Numbers
  number? integer? exact? exact-integer?
  exact-nonnegative-integer? exact-positive-integer?
- inexact->exact round sqrt sin cos tan asin acos atan number->string
+   inexact->exact abs round floor ceiling truncate sqrt sin cos tan asin acos atan number->string
  + - * / = < > <= >= zero? positive? negative? add1 sub1
  fixnum? fxzero? fx+ fx- fx* fx= fx> fx< fx<= fx>= fxquotient unsafe-fxquotient
  fx->fl fl->fx
@@ -88,7 +88,7 @@
  most-positive-fixnum
  most-negative-fixnum
 
- inexact->exact round sqrt sin cos tan asin acos atan
+   inexact->exact abs round floor ceiling truncate sqrt sin cos tan asin acos atan
  flabs flround flfloor flceiling fltruncate flsingle
  flsin flcos fltan flasin flacos flatan fllog flexp flsqrt flmin flmax flexpt
 

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2919,35 +2919,58 @@
               (unreachable))
 
 
-        (func $round (type $Prim1)
-              (param $x (ref eq))
-              (result   (ref eq))
+        ;; Generic numeric unary functions
+        ;               name      kind    flonum-expr
+        ,@(let ([ops '((abs     fx-abs   (f64.abs    (local.get $f64)))
+                       (round   fx-id    (f64.nearest (local.get $f64)))
+                       (floor   fx-id    (f64.floor   (local.get $f64)))
+                       (ceiling fx-id    (f64.ceil    (local.get $f64)))
+                       (truncate fx-id   (f64.trunc   (local.get $f64))))])
+            (for/list ([p ops])
+              (define name (car p))
+              (define kind (cadr p))
+              (define expr (caddr p))
+              (define fixstmts
+                (case kind
+                  [(fx-id) `((return (local.get $x)))]
+                  [(fx-abs) `((local.set $bits (i32.shr_s (local.get $bits) (i32.const 1)))
+                              (if (i32.lt_s (local.get $bits) (i32.const 0))
+                                  (then (local.set $bits (i32.sub (i32.const 0) (local.get $bits)))))
+                              (if (i32.lt_u (local.get $bits) (i32.const 1073741824))
+                                  (then (return (ref.i31 (i32.shl (local.get $bits) (i32.const 1)))))
+                                  (return (struct.new $Flonum
+                                                      (i32.const 0)
+                                                      (f64.convert_i32_s (local.get $bits))))))]))
+              `(func ,(string->symbol (format "$~a" name))
+                     (type $Prim1)
+                     (param $x (ref eq))
+                     (result (ref eq))
 
-              (local $bits i32)
-              (local $fl (ref $Flonum))
-              (local $f64 f64)
+                     (local $bits i32)
+                     (local $fl (ref $Flonum))
+                     (local $f64 f64)
 
-              ;; If x is a fixnum, ensure LSB = 0 and return it
-              (if (ref.test (ref i31) (local.get $x))
-                  (then
-                   (local.set $bits (i31.get_u (ref.cast (ref i31) (local.get $x))))
-                   (if (i32.eqz (i32.and (local.get $bits) (i32.const 1)))
-                       (then (return (local.get $x)))
-                       (else (call $raise-expected-number (local.get $x))
-                             (unreachable)))))
+                     ;; Fixnum case
+                     (if (ref.test (ref i31) (local.get $x))
+                         (then
+                          (local.set $bits (i31.get_s (ref.cast (ref i31) (local.get $x))))
+                          (if (i32.eqz (i32.and (local.get $bits) (i32.const 1)))
+                              (then ,@fixstmts)
+                              (else (call $raise-expected-number (local.get $x))
+                                    (unreachable)))))
 
-              ;; If x is a flonum, round using ties-to-even
-              (if (ref.test (ref $Flonum) (local.get $x))
-                  (then
-                   (local.set $fl (ref.cast (ref $Flonum) (local.get $x)))
-                   (local.set $f64 (struct.get $Flonum $v (local.get $fl)))
-                   (return (struct.new $Flonum
-                                       (i32.const 0)
-                                       (f64.nearest (local.get $f64))))))
+                     ;; Flonum case
+                     (if (ref.test (ref $Flonum) (local.get $x))
+                         (then
+                          (local.set $fl (ref.cast (ref $Flonum) (local.get $x)))
+                          (local.set $f64 (struct.get $Flonum $v (local.get $fl)))
+                          (return (struct.new $Flonum
+                                              (i32.const 0)
+                                              ,expr))))
 
-              ;; Not a number
-              (call $raise-expected-number (local.get $x))
-              (unreachable))
+                     ;; Not a number
+                     (call $raise-expected-number (local.get $x))
+                     (unreachable))))
 
         ;; Trigonometric functions
         ;               name js            inbits outbits

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -162,7 +162,7 @@
                     (equal? (immutable? (make-hasheq)) #f)
                     (equal? (immutable? (box 5)) #f)))))
  
- (list "4.3 Numbers"
+       (list "4.3 Numbers"
        (list "4.3.1 Number Types"
              (list
               (list "number?"
@@ -176,6 +176,31 @@
                          (equal? (number->string 16 16) "10")
                          (equal? (number->string 1.25)  "1.25")
                          (equal? (number->string 1.0)   "1.0")))))
+
+       (list "4.3.2 Generic Numerics"
+             (list
+              (list "abs"
+                    (and (equal? (abs 1) 1)
+                         (equal? (abs -1) 1)
+                         (equal? (abs 1.0) 1.0)))
+              (list "round"
+                    (and (equal? (round 1.2) 1)
+                         (equal? (round 2.5) 2)))
+              (list "floor"
+                    (and (equal? (floor 1.2) 1)
+                         (equal? (floor -1.2) -2)))
+              (list "ceiling"
+                    (and (equal? (ceiling 1.2) 2)
+                         (equal? (ceiling -1.2) -1)))
+              (list "truncate"
+                    (and (equal? (truncate 1.8) 1)
+                         (equal? (truncate -1.8) -1)))
+              (list "fllog"
+                    (fl= (fllog 1.0) 0.0))
+              (list "flexp"
+                    (fl= (flexp 0.0) 1.0))
+              (list "flsqrt"
+                    (fl= (flsqrt 9.0) 3.0))))
 
        (list "4.3.2.4 Trigonometric Functions"
              (list


### PR DESCRIPTION
## Summary
- support generic numeric operations `abs`, `round`, `floor`, `ceiling`, and `truncate`
- expose these primitives through compiler and runtime
- exercise new generic numerics in basic tests

## Testing
- ❌ `raco test test/test-basics.rkt` *(missing `raco`)*
- ⚠️ `apt-get update` *(403 Forbidden, unable to install Racket)*

------
https://chatgpt.com/codex/tasks/task_e_68b4085877c88322815b256d6729cc2c