### PR TITLE
Add variadic unsafe flonum min/max

### DIFF
--- a/docs/unsafe.scrbl
+++ b/docs/unsafe.scrbl
@@ -146,8 +146,8 @@ For @tech{flonums}: Unchecked versions of @racket[fl+], @racket[fl-],
 @defproc[(unsafe-fl>   [a flonum?] [b flonum?] ...) boolean?]
 @defproc[(unsafe-fl<=  [a flonum?] [b flonum?] ...) boolean?]
 @defproc[(unsafe-fl>=  [a flonum?] [b flonum?] ...) boolean?]
-@defproc[(unsafe-flmin [a flonum?] [b flonum?] ...) flonum?]
-@defproc[(unsafe-flmax [a flonum?] [b flonum?] ...) flonum?]
+@defproc[(unsafe-flmin [a flonum?] [xs flonum?] ...) flonum?]
+@defproc[(unsafe-flmax [a flonum?] [xs flonum?] ...) flonum?]
 )]{
 
 For @tech{flonums}: Unchecked versions of @racket[fl=], @racket[fl<],


### PR DESCRIPTION
## Summary
- Expand runtime to generate variadic `unsafe-flmin` and `unsafe-flmax` using a shared template with their safe counterparts
- Document variadic usage for `unsafe-flmin` and `unsafe-flmax`

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b4147489f08322a8baeb755d051da2