### PR TITLE
Implement variadic $append primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -409,7 +409,7 @@
   cons car cdr
   list              ; not first order yet
   list? length list-ref list-tail
-  append ; two arguments
+  append ; variadic list primitive
   reverse memq
   alt-reverse ; used in expansion of for/list
   map for-each
@@ -3132,7 +3132,15 @@
                 [else      '(global.get $zero)])]
              [(list ae0) ae0]
              [(list* ae0 ae1 aes*)
-              `(call ,$op (call ,$op ,ae0 ,ae1) ,(loop aes*))]))]
+             `(call ,$op (call ,$op ,ae0 ,ae1) ,(loop aes*))]))]
+
+        [(append)
+         (let loop ([aes (AExpr* ae1)])
+           (match aes
+             [(list)        '(global.get $null)]
+             [(list v)      v]
+             [(list v1 v2)  `(call $append/2 ,v1 ,v2)]
+             [(list* vs)    `(call $append ,(build-rest-args aes))]))]
 
         [(string-append)
          (let loop ([aes (AExpr* ae1)])


### PR DESCRIPTION
## Summary
- Add variadic `$append` primitive with new binary helper `$append/2`
- Replace runtime `$append` calls with `$append/2`
- Inline `append` in compiler to use `$append` or `$append/2` as needed

## Testing
- `raco test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b419aa5b9c83229eb82abbe2b37b84