### PR TITLE
Add ->fl and fl->exact-integer primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -492,8 +492,8 @@
   flabs flround flfloor flceiling fltruncate flsingle
   fllog flexp flsqrt 
   flsin flcos fltan flasin flacos flatan
-  flmin flmax flexpt
-  
+  flmin flmax flexpt ->fl fl->exact-integer
+
   byte?
 
   vector 

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -56,7 +56,7 @@
  flsin flcos fltan flasin flacos flatan
  flround flfloor flceiling fltruncate flsingle
  flexpt
- flmin flmax
+ flmin flmax ->fl fl->exact-integer
  
  byte? 
 

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -3621,6 +3621,10 @@
                (struct.new $Flonum
                            (i32.const 0)                             ;; hash = 0
                            (f64.convert_i32_s (i32.shr_u (local.get $v/i32) (i32.const 1)))))
+        (func $->fl (type $Prim1)
+              (param $v (ref eq))
+              (result (ref eq))
+              (call $fx->fl (local.get $v)))
         (func $raise-fl->fx (param $x (ref eq)) (unreachable))
 
         (func $fl->fx (type $Prim1)
@@ -3650,6 +3654,40 @@
                   (then (call $raise-fl->fx (local.get $v))
                         (unreachable)))
               ;; Convert to i32 and box
+              (local.set $i32 (i32.trunc_f64_s (local.get $t/f64)))
+              (ref.i31 (i32.shl (local.get $i32) (i32.const 1))))
+
+        (func $raise-fl->exact-integer (param $x (ref eq)) (unreachable))
+
+        (func $fl->exact-integer (type $Prim1)
+              (param $v (ref eq))
+              (result (ref eq))
+
+              (local $v/fl  (ref $Flonum))
+              (local $x/f64 f64)
+              (local $t/f64 f64)
+              (local $i32   i32)
+
+              ;; Check that v is a flonum
+              (if (i32.eqz (ref.test (ref $Flonum) (local.get $v)))
+                  (then (call $raise-check-flonum (local.get $v))
+                        (unreachable)))
+              (local.set $v/fl  (ref.cast (ref $Flonum) (local.get $v)))
+              (local.set $x/f64 (struct.get $Flonum $v (local.get $v/fl)))
+              (local.set $t/f64 (f64.trunc (local.get $x/f64)))
+              ;; Must be integer
+              (if (f64.ne (local.get $x/f64) (local.get $t/f64))
+                  (then (call $raise-fl->exact-integer (local.get $v))
+                        (unreachable)))
+              ;; NaN?
+              (if (f64.ne (local.get $t/f64) (local.get $t/f64))
+                  (then (call $raise-fl->exact-integer (local.get $v))
+                        (unreachable)))
+              ;; Check fixnum range
+              (if (i32.or (f64.gt (local.get $t/f64) (f64.const 536870911.0))
+                          (f64.lt (local.get $t/f64) (f64.const -536870912.0)))
+                  (then (call $raise-fl->exact-integer (local.get $v))
+                        (unreachable)))
               (local.set $i32 (i32.trunc_f64_s (local.get $t/f64)))
               (ref.i31 (i32.shl (local.get $i32) (i32.const 1))))
 

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -389,11 +389,15 @@
 
               (list "fx->fl"
                     (equal? (fx->fl 3) 3.0))
+              (list "->fl"
+                    (equal? (->fl 3) 3.0))
               (list "fl->fx"
                     (equal? (fl->fx 3.0) 3)
                     (equal? (fl->fx 3.1) 3)
                     (equal? (fl->fx 3.9) 3)
                     (equal? (fl->fx -0.1) 0))
+              (list "fl->exact-integer"
+                    (equal? (fl->exact-integer 3.0) 3))
               )))
 
  (list "4.4 Strings"


### PR DESCRIPTION
## Summary
- Expose `->fl` and `fl->exact-integer` in primitive lists and compiler declarations
- Implement runtime support for `->fl` and `fl->exact-integer`
- Test integer/flonum conversions

## Testing
- `raco test test/test-basics.rkt` *(failed: command not found)*
- `apt-get update` *(failed: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b41ae93c608322bf81b86de95e8360