### PR TITLE
Add exact/inexact conversion primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -464,7 +464,8 @@
   exact? exact-integer?
   exact-nonnegative-integer?
   exact-positive-integer?
-  inexact->exact 
+  inexact->exact
+  exact->inexact
   round floor ceiling truncate
   sin cos tan asin acos atan
   abs sqrt integer-sqrt integer-sqrt/remainder expt exp log

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -50,6 +50,7 @@
  exact-nonnegative-integer?
  exact-positive-integer?
  inexact->exact
+ exact->inexact
  fixnum?
  flonum?
  zero?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2532,7 +2532,7 @@
          ;; [x] exact?
          ;; [ ] inexact?
          ;; [x] inexact->exact
-         ;; [ ] exact->inexact
+         ;; [x] exact->inexact
          ;; [ ] real->single-flonum
          ;; [ ] real->double-flonum
 
@@ -2659,6 +2659,31 @@
                         (local.set $i32 (i32.trunc_f64_s (local.get $f64)))
                         (return (ref.i31 (i32.shl (local.get $i32) (i32.const 1)))))
                        (else (call $raise-expected-number (local.get $z)) (unreachable)))))
+
+              ;; Not a number
+              (call $raise-expected-number (local.get $z))
+              (unreachable))
+
+
+        (func $exact->inexact (type $Prim1)
+              (param $z (ref eq))
+              (result   (ref eq))
+
+              (local $bits i32)
+
+              ;; If z is already a flonum, return it
+              (if (ref.test (ref $Flonum) (local.get $z))
+                  (then (return (local.get $z))))
+
+              ;; If z is a fixnum, ensure LSB = 0 and convert
+              (if (ref.test (ref i31) (local.get $z))
+                  (then
+                   (local.set $bits (i31.get_u (ref.cast (ref i31) (local.get $z))))
+                   (if (i32.eqz (i32.and (local.get $bits) (i32.const 1)))
+                       (then (return (struct.new $Flonum (i32.const 0)
+                                                 (f64.convert_i32_s
+                                                  (i32.shr_u (local.get $bits)
+                                                             (i32.const 1)))))))))
 
               ;; Not a number
               (call $raise-expected-number (local.get $z))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -175,7 +175,18 @@
                     (and (equal? (number->string 42)    "42")
                          (equal? (number->string 16 16) "10")
                          (equal? (number->string 1.25)  "1.25")
-                         (equal? (number->string 1.0)   "1.0")))))
+                         (equal? (number->string 1.0)   "1.0")))
+              (list "inexact->exact"
+                    (and (equal? (inexact->exact 1) 1)
+                         (equal? (inexact->exact 1.0) 1)
+                         (equal?
+                          (with-handlers ([exn:fail:contract? (λ (_) #t)])
+                            (inexact->exact +inf.0)
+                            #f)
+                          #t)))
+              (list "exact->inexact"
+                    (and (equal? (exact->inexact 1) 1.0)
+                         (equal? (exact->inexact 1.0) 1.0))))))
 
        (list "4.3.2 Generic Numerics"
              (list


### PR DESCRIPTION
## Summary
- expose `exact->inexact` and `inexact->exact` primitives
- wire conversions into the compiler and runtime
- exercise conversions with basic numeric examples

------
https://chatgpt.com/codex/tasks/task_e_68b43e0c0e3883229408b435c0f9ada9