### PR TITLE
Add even? and odd? predicates

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -456,7 +456,7 @@
 
   + - * /
   = < > <= >=
-  zero? positive? negative? 
+  zero? positive? negative? even? odd?
   add1 sub1
 
   number?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -55,6 +55,8 @@
  zero?
  positive?
  negative?
+ even?
+ odd?
 
  ;; 4.3.2 Generic Numerics
  ;; 4.3.2.1 Arithmetic

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2527,8 +2527,8 @@
          ;; [x] zero?
          ;; [x] positive?
          ;; [x] negative?
-         ;; [ ] even?
-         ;; [ ] odd?
+         ;; [x] even?
+         ;; [x] odd?
          ;; [x] exact?
          ;; [ ] inexact?
          ;; [x] inexact->exact
@@ -3030,6 +3030,59 @@
                ;; Not a number
                (call $raise-expected-number (local.get $x))
                (unreachable))
+
+         (func $even? (type $Prim1)
+               (param $n (ref eq))
+               (result (ref eq))
+
+               (local $bits i32)
+               (local $fl (ref $Flonum))
+               (local $f64 f64)
+               (local $i32 i32)
+
+               ;; Fixnum case
+               (if (ref.test (ref i31) (local.get $n))
+                   (then
+                    (local.set $bits (i31.get_s (ref.cast (ref i31) (local.get $n))))
+                    (if (i32.eqz (i32.and (local.get $bits) (i32.const 1)))
+                        (then
+                         (local.set $i32 (i32.shr_s (local.get $bits) (i32.const 1)))
+                         (if (i32.eqz (i32.and (local.get $i32) (i32.const 1)))
+                             (then (return (global.get $true)))
+                             (else (return (global.get $false)))))
+                        (else (call $raise-expected-number (local.get $n)) (unreachable)))))
+
+               ;; Flonum case
+               (if (ref.test (ref $Flonum) (local.get $n))
+                   (then
+                    (local.set $fl (ref.cast (ref $Flonum) (local.get $n)))
+                    (local.set $f64 (struct.get $Flonum $v (local.get $fl)))
+                    (if (f64.ne (local.get $f64) (local.get $f64))
+                        (then (call $raise-expected-number (local.get $n)) (unreachable)))
+                    (if (f64.eq (local.get $f64) (f64.const +inf))
+                        (then (call $raise-expected-number (local.get $n)) (unreachable)))
+                    (if (f64.eq (local.get $f64) (f64.const -inf))
+                        (then (call $raise-expected-number (local.get $n)) (unreachable)))
+                    (if (f64.eq (f64.floor (local.get $f64)) (local.get $f64))
+                        (then
+                         (local.set $i32 (i32.trunc_f64_s (local.get $f64)))
+                         (if (i32.eqz (i32.and (local.get $i32) (i32.const 1)))
+                             (then (return (global.get $true)))
+                             (else (return (global.get $false)))))
+                        (else (call $raise-expected-number (local.get $n)) (unreachable)))))
+
+               ;; Not an integer
+               (call $raise-expected-number (local.get $n))
+               (unreachable))
+
+         (func $odd? (type $Prim1)
+               (param $n (ref eq))
+               (result (ref eq))
+
+               (if (result (ref eq))
+                   (ref.eq (call $even? (local.get $n)) (global.get $true))
+                   (then (global.get $false))
+                   (else (global.get $true))))
 
 
          (func $integer? (type $Prim1)

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -194,7 +194,15 @@
                          (equal? (ceiling -1.2) -1.)))
               (list "truncate"
                     (and (equal? (truncate 1.8) 1.)
-                         (equal? (truncate -1.8) -1.)))))
+                         (equal? (truncate -1.8) -1.)))
+              (list "even?"
+                    (and (equal? (even? 10) #t)
+                         (equal? (even? 11) #f)
+                         (equal? (even? 10.0) #t)))
+              (list "odd?"
+                    (and (equal? (odd? 10) #f)
+                         (equal? (odd? 11) #t)
+                         (equal? (odd? 10.0) #f)))))
 
       (list "4.3.2.3 Powers and Roots"
             (list


### PR DESCRIPTION
## Summary
- add even? and odd? to the primitive set
- implement runtime support for parity predicates
- test even? and odd? on integers and flonums

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found: raco)*

------
https://chatgpt.com/codex/tasks/task_e_68b43f7989e48322b0a75276233181fe