### PR TITLE
Add exact integer rounding primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -466,6 +466,7 @@
   exact-positive-integer?
   inexact->exact
   exact->inexact
+  exact-round exact-floor exact-ceiling exact-truncate
   round floor ceiling truncate
   sin cos tan asin acos atan sinh cosh tanh
   degrees->radians radians->degrees

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -69,6 +69,7 @@
  add1
  sub1
  abs
+ exact-round exact-floor exact-ceiling exact-truncate
  round
  floor
  ceiling

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -201,6 +201,18 @@
               (list "truncate"
                     (and (equal? (truncate 1.8) 1.)
                          (equal? (truncate -1.8) -1.)))
+              (list "exact-round"
+                    (and (equal? (exact-round 1.2) 1)
+                         (equal? (exact-round 2.5) 2)))
+              (list "exact-floor"
+                    (and (equal? (exact-floor 1.2) 1)
+                         (equal? (exact-floor -1.2) -2)))
+              (list "exact-ceiling"
+                    (and (equal? (exact-ceiling 1.2) 2)
+                         (equal? (exact-ceiling -1.2) -1)))
+              (list "exact-truncate"
+                    (and (equal? (exact-truncate 1.8) 1)
+                         (equal? (exact-truncate -1.8) -1)))
               (list "even?"
                     (and (equal? (even? 10) #t)
                          (equal? (even? 11) #f)


### PR DESCRIPTION
## Summary
- add exact-round, exact-floor, exact-ceiling, and exact-truncate primitives to the runtime
- expose the new primitives to the compiler and base module
- cover exact rounding behaviors with new tests

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b44aa21f388322b8a01b4717a180ce