### PR TITLE
Implement bitwise operations

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -468,11 +468,12 @@
   exact->inexact
   exact-round exact-floor exact-ceiling exact-truncate
   round floor ceiling truncate
-  sin  cos  tan  asin  acos  atan 
+  sin  cos  tan  asin  acos  atan
   sinh cosh tanh asinh acosh atanh
   degrees->radians radians->degrees
   abs sqrt integer-sqrt integer-sqrt/remainder expt exp log
-  
+  bitwise-ior bitwise-and bitwise-xor
+
   fixnum? fxzero?
   fx+ fx- fx*
   fx= fx> fx< fx<= fx>=
@@ -3122,6 +3123,23 @@
                                   ,(first aes)
                                   ,(loop (rest aes))))))
             `(call ,$cmp ,c0 ,xs)])]
+
+        [(bitwise-and bitwise-ior bitwise-xor)
+         (define aes (AExpr* ae1))
+         (when (null? aes) (error 'primapp "too few arguments: ~a" sym))
+         (define $op (case sym
+                        [(bitwise-and) '$bitwise-and/2]
+                        [(bitwise-ior) '$bitwise-ior/2]
+                        [(bitwise-xor) '$bitwise-xor/2]))
+         (let loop ([aes aes])
+           (match aes
+             [(list)
+              (case sym
+                [(bitwise-and) (Imm -1)]
+                [else           '(global.get $zero)])]
+             [(list ae0) ae0]
+             [(list* ae0 ae1 aes*)
+              `(call ,$op (call ,$op ,ae0 ,ae1) ,(loop aes*))]))]
 
         [(fxand fxior fxxor)
          (define aes (AExpr* ae1))

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -107,8 +107,11 @@
  acosh
  atanh
 ;; 4.3.2.5 Complex Numbers
- ;; 4.3.2.6 Bitwise Operations
- ;; 4.3.2.7 Random Numbers
+;; 4.3.2.6 Bitwise Operations
+ bitwise-ior
+ bitwise-and
+ bitwise-xor
+;; 4.3.2.7 Random Numbers
  ;; 4.3.2.8 Other Randomness Utilities (racket/random)
  ;; 4.3.2.9 Number–String Conversions
  number->string

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -299,6 +299,18 @@
                     (and (equal? (atanh 0) 0)
                          (equal? (atanh 0.) 0.)))))
 
+       (list "4.3.2.6 Bitwise Operations"
+             (list
+              (list "bitwise-ior"
+                    (and (equal? (bitwise-ior 1 2) 3)
+                         (equal? (bitwise-ior -32 1) -31)))
+              (list "bitwise-and"
+                    (and (equal? (bitwise-and 1 2) 0)
+                         (equal? (bitwise-and -32 -1) -32)))
+              (list "bitwise-xor"
+                    (and (equal? (bitwise-xor 1 5) 4)
+                         (equal? (bitwise-xor -32 -1) 31)))))
+
        (list "4.3.2.10 Extra Constants and Functions"
              (list
               (list "degrees->radians"


### PR DESCRIPTION
## Summary
- add bitwise-ior, bitwise-and, and bitwise-xor primitives
- implement variadic bitwise operations in runtime using shared template
- inline bitwise primitives and add basic tests

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b490a05d4c8322abd8fbda6d5f0dd9