### PR TITLE
Implement quotient primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -454,7 +454,7 @@
 
   number->string
 
-  + - * / remainder
+  + - * / quotient remainder
   = < > <= >=
   zero? positive? negative? even? odd?
   add1 sub1

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -71,6 +71,7 @@
  -
  *
  /
+ quotient
  remainder
  add1
  sub1

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -3236,10 +3236,79 @@
          ;; [/] /
          ;; TODO  The functions + - * / currently uses 2 arguments. Make them variadic.
          
-         ;; [ ] quotient
-         ;; TODO  Implement `quotient` using `fxquotient`.
-         
-         ;; [x] remainder
+        ;; [x] quotient
+
+        (func $quotient (type $Prim2)
+              (param $n (ref eq))
+              (param $m (ref eq))
+              (result   (ref eq))
+
+              (local $nu i32)
+              (local $mu i32)
+              (local $fl (ref $Flonum))
+              (local $nf f64)
+              (local $mf f64)
+              (local $qf f64)
+
+              ;; Case 1: both fixnums
+              (if (ref.test (ref i31) (local.get $n))
+                  (then (local.set $nu (i31.get_s (ref.cast i31ref (local.get $n))))
+                        (if (i32.eqz (i32.and (local.get $nu) (i32.const 1)))
+                            (then (if (ref.test (ref i31) (local.get $m))
+                                      (then (local.set $mu (i31.get_s (ref.cast i31ref (local.get $m))))
+                                            (if (i32.eqz (i32.and (local.get $mu) (i32.const 1)))
+                                                (then (return (call $fxquotient (local.get $n) (local.get $m)))))))))
+
+              ;; Case 2: flonum/inexact
+              ;; convert n to f64
+              (if (ref.test (ref $Flonum) (local.get $n))
+                  (then (local.set $fl (ref.cast (ref $Flonum) (local.get $n)))
+                        (local.set $nf (struct.get $Flonum $v (local.get $fl))))
+                  (else (if (ref.test (ref i31) (local.get $n))
+                            (then (local.set $nu (i31.get_s (ref.cast i31ref (local.get $n))))
+                                  (if (i32.eqz (i32.and (local.get $nu) (i32.const 1)))
+                                      (then (local.set $nf (f64.convert_i32_s (i32.shr_s (local.get $nu) (i32.const 1)))))
+                                      (else (call $raise-expected-number (local.get $n)) (unreachable))))
+                            (else (call $raise-expected-number (local.get $n)) (unreachable)))))
+
+              ;; ensure n is a finite integer
+              (if (f64.eq (local.get $nf) (f64.const inf))
+                  (then (call $raise-expected-number (local.get $n)) (unreachable)))
+              (if (f64.eq (local.get $nf) (f64.const -inf))
+                  (then (call $raise-expected-number (local.get $n)) (unreachable)))
+              (if (f64.eq (f64.floor (local.get $nf)) (local.get $nf))
+                  (then)
+                  (else (call $raise-expected-number (local.get $n)) (unreachable)))
+
+              ;; convert m to f64
+              (if (ref.test (ref $Flonum) (local.get $m))
+                  (then (local.set $fl (ref.cast (ref $Flonum) (local.get $m)))
+                        (local.set $mf (struct.get $Flonum $v (local.get $fl))))
+                  (else (if (ref.test (ref i31) (local.get $m))
+                            (then (local.set $mu (i31.get_s (ref.cast i31ref (local.get $m))))
+                                  (if (i32.eqz (i32.and (local.get $mu) (i32.const 1)))
+                                      (then (local.set $mf (f64.convert_i32_s (i32.shr_s (local.get $mu) (i32.const 1)))))
+                                      (else (call $raise-expected-number (local.get $m)) (unreachable))))
+                            (else (call $raise-expected-number (local.get $m)) (unreachable)))))
+
+              ;; ensure m is a finite integer
+              (if (f64.eq (local.get $mf) (f64.const inf))
+                  (then (call $raise-expected-number (local.get $m)) (unreachable)))
+              (if (f64.eq (local.get $mf) (f64.const -inf))
+                  (then (call $raise-expected-number (local.get $m)) (unreachable)))
+              (if (f64.eq (f64.floor (local.get $mf)) (local.get $mf))
+                  (then)
+                  (else (call $raise-expected-number (local.get $m)) (unreachable)))
+
+              ;; divide by zero?
+              (if (f64.eq (local.get $mf) (f64.const 0.0))
+                  (then (call $raise-division-by-zero) (unreachable)))
+
+              ;; compute quotient in flonum
+              (local.set $qf (f64.trunc (f64.div (local.get $nf) (local.get $mf))))
+              (return (struct.new $Flonum (i32.const 0) (local.get $qf))))
+
+        ;; [x] remainder
          ;; [ ] quotient/remainder
          ;; [ ] modulo
          ;; TODO  Implement `remainder`, quotient/remainder` and `modulo`.

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -185,6 +185,11 @@
 
        (list "4.3.2.1 Arithmetic"
              (list
+              (list "quotient"
+                    (and (equal? (quotient 10 3) 3)
+                         (equal? (quotient -10.0 3) -3.0)
+                         (equal? (quotient 10.0 -3) -3.0)
+                         (equal? (quotient -10 -3) 3)))
               (list "remainder"
                     (and (equal? (remainder 10 3) 1)
                          (equal? (remainder -10.0 3) -1.0)


### PR DESCRIPTION
## Summary
- Implement `quotient` in the WebAssembly runtime using `fxquotient`
- Expose `quotient` through compiler and primitive exports
- Expand arithmetic examples in the basics suite

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49542a4008322acc5e82ca04d6d6f