### PR TITLE
Add gcd and lcm primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -457,7 +457,7 @@
   + - * / quotient remainder quotient/remainder
   = < > <= >=
   zero? positive? negative? even? odd?
-  add1 sub1
+  add1 sub1 gcd lcm
 
   number?
   integer?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -76,6 +76,8 @@
  quotient/remainder
  add1
  sub1
+ gcd
+ lcm
  abs
  exact-round exact-floor exact-ceiling exact-truncate
  round

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -3856,7 +3856,101 @@
                ;; --- Divide using $fl/ ---
                (call $fl/ (local.get $x/fl) (local.get $y/fl)))
 
-         ,@(let ()
+        (func $gcd/2 (type $Prim2)
+              (param $n (ref eq))
+              (param $m (ref eq))
+              (result (ref eq))
+
+              (local $tmp (ref eq))
+
+              (local.set $n (call $abs (local.get $n)))
+              (local.set $m (call $abs (local.get $m)))
+              (block $done
+                     (loop $loop
+                           (br_if $done (ref.eq (call $zero? (local.get $m)) (global.get $true)))
+                           (local.set $tmp (local.get $m))
+                           (local.set $m (call $remainder (local.get $n) (local.get $m)))
+                           (local.set $n (local.get $tmp))
+                           (br $loop)))
+              (local.get $n))
+
+        (func $gcd (type $Prim>=0)
+              (param $xs0 (ref eq))
+              (result (ref eq))
+
+              (local $xs   (ref eq))
+              (local $node (ref $Pair))
+              (local $v    (ref eq))
+              (local $r    (ref eq))
+
+              (local.set $xs
+                         (if (result (ref eq))
+                             (ref.test (ref $Args) (local.get $xs0))
+                             (then (call $rest-arguments->list
+                                         (ref.cast (ref $Args) (local.get $xs0))
+                                         (i32.const 0)))
+                             (else (local.get $xs0))))
+              (local.set $r ,(Imm 0))
+              (block $done
+                     (loop $loop
+                           (br_if $done (ref.eq (local.get $xs) (global.get $null)))
+                           (local.set $node (ref.cast (ref $Pair) (local.get $xs)))
+                           (local.set $v    (struct.get $Pair $a (local.get $node)))
+                           (local.set $r    (call $gcd/2 (local.get $r) (local.get $v)))
+                           (local.set $xs   (struct.get $Pair $d (local.get $node)))
+                           (br $loop)))
+              (local.get $r))
+
+        (func $lcm/2 (type $Prim2)
+              (param $n (ref eq))
+              (param $m (ref eq))
+              (result (ref eq))
+
+              (local $g (ref eq))
+
+              (local.set $n (call $abs (local.get $n)))
+              (local.set $m (call $abs (local.get $m)))
+              (if (ref.eq (call $zero? (local.get $n)) (global.get $true))
+                  (then (if (ref.eq (call $zero? (local.get $m)) (global.get $true))
+                            (then (if (ref.eq (call $exact? (local.get $n)) (global.get $true))
+                                      (return (local.get $n))
+                                      (if (ref.eq (call $exact? (local.get $m)) (global.get $true))
+                                          (return (local.get $m))
+                                          (return (local.get $n)))))
+                            (else (return (local.get $n)))))
+              (if (ref.eq (call $zero? (local.get $m)) (global.get $true))
+                  (then (return (local.get $m))))
+              (local.set $g (call $gcd/2 (local.get $n) (local.get $m)))
+              (call $/ (call $* (local.get $n) (local.get $m)) (local.get $g)))
+
+        (func $lcm (type $Prim>=0)
+              (param $xs0 (ref eq))
+              (result (ref eq))
+
+              (local $xs   (ref eq))
+              (local $node (ref $Pair))
+              (local $v    (ref eq))
+              (local $r    (ref eq))
+
+              (local.set $xs
+                         (if (result (ref eq))
+                             (ref.test (ref $Args) (local.get $xs0))
+                             (then (call $rest-arguments->list
+                                         (ref.cast (ref $Args) (local.get $xs0))
+                                         (i32.const 0)))
+                             (else (local.get $xs0))))
+              (local.set $r ,(Imm 1))
+              (block $done
+                     (loop $loop
+                           (br_if $done (ref.eq (local.get $xs) (global.get $null)))
+                           (local.set $node (ref.cast (ref $Pair) (local.get $xs)))
+                           (local.set $v    (struct.get $Pair $a (local.get $node)))
+                           (local.set $r    (call $lcm/2 (local.get $r) (local.get $v)))
+                           (local.set $xs   (struct.get $Pair $d (local.get $node)))
+                           (br $loop)))
+              (local.get $r))
+
+        ,@(let ()
              (define (gencmp cmp fxcmp flcmp)
                `(func ,cmp
                       (param $x (ref eq))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -245,6 +245,12 @@
                     (and (equal? (odd? 10) #f)
                          (equal? (odd? 11) #t)
                          (equal? (odd? 10.0) #f)))
+              (list "gcd"
+                    (and (equal? (gcd 10) 10)
+                         (equal? (gcd 12 81.0) 3.0)))
+              (list "lcm"
+                    (and (equal? (lcm 10) 10)
+                         (equal? (lcm 3 4.0) 12.0)))
               ))
 
        (list "4.3.2.3 Powers and Roots"


### PR DESCRIPTION
## Summary
- implement numeric gcd and lcm primitives in runtime
- expose gcd and lcm through compiler and Racket primitive list
- cover gcd and lcm behavior with basic tests

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b591ff1a2883229d518e14c4e66e60