### PR TITLE
Add inexact? numeric predicate

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -464,6 +464,7 @@
   exact? exact-integer?
   exact-nonnegative-integer?
   exact-positive-integer?
+  inexact?
   inexact->exact
   exact->inexact
   exact-round exact-floor exact-ceiling exact-truncate

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -55,6 +55,7 @@
  exact-integer?
  exact-nonnegative-integer?
  exact-positive-integer?
+ inexact?
  inexact->exact
  exact->inexact
  fixnum?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2605,7 +2605,7 @@
          ;; [x] even?
          ;; [x] odd?
          ;; [x] exact?
-         ;; [ ] inexact?
+         ;; [x] inexact?
          ;; [x] inexact->exact
          ;; [x] exact->inexact
          ;; [ ] real->single-flonum
@@ -2631,7 +2631,7 @@
                (param $z (ref eq))
                (result   (ref eq))
 
-               (local $bits i32)               
+               (local $bits i32)
                (if (result (ref eq))
                    (ref.test (ref i31) (local.get $z))
                    (then (local.set $bits (i31.get_u (ref.cast (ref i31) (local.get $z))))
@@ -2641,9 +2641,19 @@
                              (else (global.get $false))))
                    (else (global.get $false))))
 
-         (func $exact-integer? (type $Prim1)
-               (param $v (ref eq))
+         (func $inexact? (type $Prim1)
+               ;; A number is inexact if it's a flonum
+               (param $z (ref eq))
                (result   (ref eq))
+
+               (if (result (ref eq))
+                   (ref.test (ref $Flonum) (local.get $z))
+                   (then (global.get $true))
+                   (else (global.get $false))))
+
+         (func $exact-integer? (type $Prim1)
+              (param $v (ref eq))
+              (result   (ref eq))
 
                (local $bits i32)
                

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -176,6 +176,10 @@
                          (equal? (number->string 16 16) "10")
                          (equal? (number->string 1.25)  "1.25")
                          (equal? (number->string 1.0)   "1.0")))
+              (list "inexact?"
+                    (and (equal? (inexact? 1.0) #t)
+                         (equal? (inexact? 1)   #f)
+                         (equal? (procedure-arity inexact?) 1)))
               (list "inexact->exact"
                     (and (equal? (inexact->exact 1)   1)
                          (equal? (inexact->exact 1.0) 1)))


### PR DESCRIPTION
## Summary
- implement `inexact?` primitive in the WebAssembly runtime
- expose `inexact?` through compiler and primitives lists
- exercise numeric inexact predicate in basics tests

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a56fc7b083229bf600ecdab8765f