### PR TITLE
Add sgn primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -477,7 +477,7 @@
   sin  cos  tan  asin  acos  atan
   sinh cosh tanh asinh acosh atanh
   degrees->radians radians->degrees
-  abs sqrt integer-sqrt integer-sqrt/remainder expt exp log
+  abs sgn sqrt integer-sqrt integer-sqrt/remainder expt exp log
   bitwise-ior bitwise-and bitwise-xor
 
   fixnum? fxzero?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -88,6 +88,7 @@
  gcd
  lcm
  abs
+ sgn
  exact-round exact-floor exact-ceiling exact-truncate
  round
  floor

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -3798,6 +3798,48 @@
                      (call $raise-expected-number (local.get $x))
                      (unreachable))))
 
+        (func $sgn (type $Prim1)
+              (param $x (ref eq))
+              (result (ref eq))
+
+              (local $bits i32)
+              (local $fl   (ref $Flonum))
+              (local $f64  f64)
+
+              ;; Fixnum case
+              (if (ref.test (ref i31) (local.get $x))
+                  (then
+                   (local.set $bits (i31.get_s (ref.cast (ref i31) (local.get $x))))
+                   (if (i32.eqz (i32.and (local.get $bits) (i32.const 1)))
+                       (then
+                        (local.set $bits (i32.shr_s (local.get $bits) (i32.const 1)))
+                        (if (i32.eqz (local.get $bits))
+                            (return (local.get $x))
+                            (if (i32.gt_s (local.get $bits) (i32.const 0))
+                                (return ,(Imm 1))
+                                (return ,(Imm -1)))))
+                       (else (call $raise-expected-number (local.get $x))
+                             (unreachable)))))
+
+              ;; Flonum case
+              (if (ref.test (ref $Flonum) (local.get $x))
+                  (then
+                   (local.set $fl (ref.cast (ref $Flonum) (local.get $x)))
+                   (local.set $f64 (struct.get $Flonum $v (local.get $fl)))
+                   (if (f64.eq (local.get $f64) (f64.const 0.0))
+                       (return (local.get $x))
+                       (if (f64.gt (local.get $f64) (f64.const 0.0))
+                           (return (struct.new $Flonum (i32.const 0) (f64.const 1.0)))
+                           (if (f64.lt (local.get $f64) (f64.const 0.0))
+                               (return (struct.new $Flonum (i32.const 0) (f64.const -1.0)))
+                               (return (struct.new $Flonum (i32.const 0)
+                                                     (f64.div (f64.const 0.0)
+                                                              (f64.const 0.0))))))))
+
+              ;; Not a number
+              (call $raise-expected-number (local.get $x))
+              (unreachable))
+
         ;; Exact integer rounding functions
         ;; Implements: $exact-round $exact-floor $exact-ceiling $exact-truncate
         ,@(let ([ops '((exact-round   f64.nearest)

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -248,13 +248,21 @@
        
        (list "4.3.2 Generic Numerics"
              (list
-              (list "abs"
-                    (and (equal? (abs 1) 1)
-                         (equal? (abs -1) 1)
-                         (equal? (abs 1.0) 1.0)))
-              (list "round"
-                    (and (equal? (round 1.2) 1.)
-                         (equal? (round 2.5) 2.)))
+             (list "abs"
+                   (and (equal? (abs 1) 1)
+                        (equal? (abs -1) 1)
+                        (equal? (abs 1.0) 1.0)))
+             (list "sgn"
+                   (and (equal? (sgn 10) 1)
+                        (equal? (sgn -10) -1)
+                        (equal? (sgn 10.0) 1.0)
+                        (equal? (sgn -10.0) -1.0)
+                        (eqv? (sgn 0.0) 0.0)
+                        (eqv? (sgn -0.0) -0.0)
+                        (nan? (sgn +nan.0))))
+             (list "round"
+                   (and (equal? (round 1.2) 1.)
+                        (equal? (round 2.5) 2.)))
               (list "floor"
                     (and (equal? (floor 1.2) 1.)
                          (equal? (floor -1.2) -2.)))


### PR DESCRIPTION
## Summary
- implement `sgn` numeric primitive in the WebAssembly runtime
- expose `sgn` through primitive bindings and compiler
- cover `sgn` behavior in basic numeric tests

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*
- `apt-get install -y racket` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aebe37f48322b409c578136dc886