### PR TITLE
Implement integer-length primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -481,6 +481,7 @@
   abs sgn sqr sqrt integer-sqrt integer-sqrt/remainder expt exp log
 
   bitwise-ior bitwise-and bitwise-xor
+  integer-length
 
   fixnum? fxzero?
   fx+ fx- fx*

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -126,6 +126,7 @@
  bitwise-ior
  bitwise-and
  bitwise-xor
+ integer-length
 ;; 4.3.2.7 Random Numbers
  ;; 4.3.2.8 Other Randomness Utilities (racket/random)
  ;; 4.3.2.9 Number–String Conversions

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -4373,6 +4373,45 @@
                     (gen-bitop 'bitwise-xor '$fxxor/2)))
 
 
+        (func $integer-length (type $Prim1)
+              (param $n (ref eq))
+              (result (ref eq))
+
+              (local $bits  i32)
+              (local $n/fx i32)
+              (local $len   i32)
+
+              (if (ref.test (ref i31) (local.get $n))
+                  (then
+                   ;; 1. If the argument is a non-number then raise.
+                   (local.set $bits (i31.get_u (ref.cast (ref i31) (local.get $n))))
+                   (if (i32.eqz (i32.and (local.get $bits) (i32.const 1)))
+                       (then
+                        ;; 2. Extract the number.
+                        (local.set $n/fx (i32.shr_s (i32.shl (local.get $bits) (i32.const 1))
+                                                   (i32.const 2)))
+                        ;; 3. Compute the integer length.
+                        (if (i32.ge_s (local.get $n/fx) (i32.const 0))
+                            (then
+                             (if (i32.eqz (local.get $n/fx))
+                                 (then (ref.i31 (i32.const 0)))
+                                 (else
+                                  (local.set $len (i32.sub (i32.const 32)
+                                                           (i32.clz (local.get $n/fx))))
+                                  (ref.i31 (i32.shl (local.get $len)
+                                                    (i32.const 1))))))
+                            (else
+                             (local.set $len (i32.sub (i32.const 32)
+                                                      (i32.clz (i32.xor (local.get $n/fx)
+                                                                         (i32.const -1)))))
+                             (ref.i31 (i32.shl (local.get $len)
+                                               (i32.const 1))))))
+                       (else (call $raise-expected-number (local.get $n))
+                             (unreachable))))
+                  (else (call $raise-expected-number (local.get $n))
+                        (unreachable))))
+
+
          ;;;
          ;;;  4.3.4 Fixnums
          ;;;

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -393,7 +393,13 @@
                          (equal? (bitwise-and -32 -1) -32)))
               (list "bitwise-xor"
                     (and (equal? (bitwise-xor 1 5) 4)
-                         (equal? (bitwise-xor -32 -1) 31)))))
+                         (equal? (bitwise-xor -32 -1) 31)))
+              (list "integer-length"
+                    (and (equal? (integer-length 8) 4)
+                         (equal? (integer-length -8) 3)
+                         (equal? (integer-length 0) 0)
+                         (with-handlers ([exn:fail? (λ _ #t)])
+                           (begin (integer-length #t) #f))))))
 
        (list "4.3.2.10 Extra Constants and Functions"
       (list


### PR DESCRIPTION
## Summary
- add support for `integer-length` primitive in runtime
- expose `integer-length` via primitive lists and compiler
- handle invalid inputs for `integer-length` early

------
https://chatgpt.com/codex/tasks/task_e_68b5c3304d5c8322bef78a8216c2d458