### PR TITLE
Add string->number primitive and tests

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3086,6 +3086,7 @@
          [(procedure-arity-includes?)  (inline-prim/optional/default sym ae1 2  3 (Imm #f))]
          [(make-hasheq)                (inline-prim/optional sym ae1 0 1)]
          [(number->string)             (inline-prim/optional/default sym ae1 1  2 (Imm #f))]
+         [(string->number)             (inline-prim/optional sym ae1 1 5)]
          [(make-struct-type)           (inline-prim/optional/default sym ae1 4 11 (Imm #f))]
          [(make-struct-field-accessor) (inline-prim/optional/default sym ae1 2  5 (Imm #f))]
          [(make-struct-field-mutator)  (inline-prim/optional/default sym ae1 2  5 (Imm #f))]

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -131,6 +131,7 @@
  ;; 4.3.2.8 Other Randomness Utilities (racket/random)
  ;; 4.3.2.9 Number–String Conversions
  number->string
+ string->number
  ;; 4.3.2.10 Extra Constants and Functions (racket/math)
 
  degrees->radians

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -176,6 +176,10 @@
                          (equal? (number->string 16 16) "10")
                          (equal? (number->string 1.25)  "1.25")
                          (equal? (number->string 1.0)   "1.0")))
+              (list "string->number"
+                    (and (equal? (string->number "42") 42)
+                         (equal? (string->number "111" 7) 57)
+                         (equal? (string->number "hello") #f)))
               (list "inexact?"
                     (and (equal? (inexact? 1.0) #t)
                          (equal? (inexact? 1)   #f)


### PR DESCRIPTION
## Summary
- implement `string->number` primitive in the Wasm runtime
- expose `string->number` in primitives and compiler
- add basic tests for `string->number`

## Testing
- `raco test test/test-basics.rkt` *(command failed: raco: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c9ea36cc83229a1043e42656fd97