### PR TITLE
Add bitwise inspection primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -481,7 +481,7 @@
   order-of-magnitude
   abs sgn sqr sqrt integer-sqrt integer-sqrt/remainder expt exp log
 
-  bitwise-ior bitwise-and bitwise-xor
+  bitwise-ior bitwise-and bitwise-xor bitwise-not bitwise-bit-set? bitwise-first-bit-set
   integer-length
 
   fixnum? fxzero?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -126,6 +126,9 @@
  bitwise-ior
  bitwise-and
  bitwise-xor
+ bitwise-not
+ bitwise-bit-set?
+ bitwise-first-bit-set
  integer-length
 ;; 4.3.2.7 Random Numbers
  ;; 4.3.2.8 Other Randomness Utilities (racket/random)

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -4373,6 +4373,78 @@
                     (gen-bitop 'bitwise-xor '$fxxor/2)))
 
 
+        (func $bitwise-not (type $Prim1)
+              (param $x (ref eq)) (result (ref eq))
+              (local $x/fx i32)   ; raw fixnum bits
+              (local $x/i  i32)   ; unboxed signed i32
+              (if (ref.test (ref i31) (local.get $x))
+                  (then
+                   (local.set $x/fx (i31.get_u (ref.cast (ref i31) (local.get $x))))
+                   (if (i32.eqz (i32.and (local.get $x/fx) (i32.const 1)))
+                       (then
+                        (local.set $x/i (i32.shr_s (local.get $x/fx) (i32.const 1)))
+                        (ref.i31 (i32.shl (i32.xor (local.get $x/i) (i32.const -1))
+                                          (i32.const 1))))
+                       (else (call $raise-expected-number (local.get $x))
+                             (unreachable))))
+                  (else (call $raise-expected-number (local.get $x)) (unreachable))))
+
+        (func $bitwise-bit-set? (type $Prim2)
+              (param $n (ref eq)) (param $m (ref eq)) (result (ref eq))
+              (local $n/fx i32)   ; raw bits of n
+              (local $m/fx i32)   ; raw bits of m
+              (local $n/i  i32)   ; unboxed signed n
+              (local $m/i  i32)   ; unboxed unsigned m
+              (if (ref.test (ref i31) (local.get $n))
+                  (then
+                   (local.set $n/fx (i31.get_u (ref.cast (ref i31) (local.get $n))))
+                   (if (i32.eqz (i32.and (local.get $n/fx) (i32.const 1)))
+                       (then
+                        (local.set $n/i (i32.shr_s (local.get $n/fx) (i32.const 1)))
+                        (if (ref.test (ref i31) (local.get $m))
+                            (then
+                             (local.set $m/fx (i31.get_u (ref.cast (ref i31) (local.get $m))))
+                             (if (i32.eqz (i32.and (local.get $m/fx) (i32.const 1)))
+                                 (then
+                                  (local.set $m/i (i32.shr_u (local.get $m/fx) (i32.const 1)))
+                                  (if (result (ref eq))
+                                      (i32.ge_u (local.get $m/i) (i32.const 30))
+                                      (then (if (result (ref eq))
+                                                 (i32.lt_s (local.get $n/i) (i32.const 0))
+                                                 (then (global.get $true))
+                                                 (else (global.get $false))))
+                                      (else (if (result (ref eq))
+                                                 (i32.eqz (i32.and (local.get $n/i)
+                                                                   (i32.shl (i32.const 1)
+                                                                            (local.get $m/i))))
+                                                 (then (global.get $false))
+                                                 (else (global.get $true))))))
+                                 (else (call $raise-expected-number (local.get $m))
+                                       (unreachable))))
+                            (else (call $raise-expected-number (local.get $m))
+                                  (unreachable))))
+                       (else (call $raise-expected-number (local.get $n))
+                             (unreachable))))
+                  (else (call $raise-expected-number (local.get $n)) (unreachable))))
+
+        (func $bitwise-first-bit-set (type $Prim1)
+              (param $n (ref eq)) (result (ref eq))
+              (local $n/fx i32)
+              (local $n/i  i32)
+              (if (ref.test (ref i31) (local.get $n))
+                  (then
+                   (local.set $n/fx (i31.get_u (ref.cast (ref i31) (local.get $n))))
+                   (if (i32.eqz (i32.and (local.get $n/fx) (i32.const 1)))
+                       (then
+                        (local.set $n/i (i32.shr_s (local.get $n/fx) (i32.const 1)))
+                        (if (i32.eqz (local.get $n/i))
+                            (then (ref.i31 (i32.const -2)))
+                            (else (ref.i31 (i32.shl (i32.ctz (local.get $n/i))
+                                                   (i32.const 1))))))
+                       (else (call $raise-expected-number (local.get $n))
+                             (unreachable))))
+                  (else (call $raise-expected-number (local.get $n)) (unreachable))))
+
         (func $integer-length (type $Prim1)
               (param $n (ref eq))
               (result (ref eq))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -406,6 +406,16 @@
               (list "bitwise-xor"
                     (and (equal? (bitwise-xor 1 5) 4)
                          (equal? (bitwise-xor -32 -1) 31)))
+              (list "bitwise-not"
+                    (and (equal? (bitwise-not 5) -6)
+                         (equal? (bitwise-not -1) 0)))
+              (list "bitwise-bit-set?"
+                    (and (bitwise-bit-set? 5 0)
+                         (bitwise-bit-set? 5 2)
+                         (bitwise-bit-set? -5 20)))
+              (list "bitwise-first-bit-set"
+                    (and (equal? (bitwise-first-bit-set 128) 7)
+                         (equal? (bitwise-first-bit-set -8) 3)))
               (list "integer-length"
                     (and (equal? (integer-length 8) 4)
                          (equal? (integer-length -8) 3)


### PR DESCRIPTION
## Summary
- implement `bitwise-not`, `bitwise-bit-set?`, and `bitwise-first-bit-set` primitives in the WebAssembly runtime
- wire new primitives into the compiler and primitive exports
- add explicit fixnum validation for the bitwise primitives


------
https://chatgpt.com/codex/tasks/task_e_68b5f8e18db4832285e8fbb7645995d7