### PR TITLE
Implement random primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -484,6 +484,7 @@
   bitwise-ior bitwise-and bitwise-xor bitwise-not bitwise-bit-set?
   bitwise-first-bit-set  ; note : added in 8.16
   integer-length
+  random
 
   fixnum? fxzero?
   fx+ fx- fx*
@@ -3098,6 +3099,7 @@
          [(for-each)                   (inline-prim/variadic sym ae1 2 1)]
 
          [(hash-ref)                   (inline-prim/optional sym ae1 2 3)]
+        [(random)                      (inline-prim/optional sym ae1 0 2)]
          [(fx-/wraparound)             (inline-prim/variadic sym ae1 1)]            ; actual arity: 1,2
 
          [(flmin flmax unsafe-flmin unsafe-flmax) (inline-prim/variadic sym ae1 1)] ; at least 1

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -130,7 +130,8 @@
  bitwise-not
  bitwise-bit-set?
  bitwise-first-bit-set  ; added in version 8.16
- integer-length 
+ integer-length
+ random
  ;; 4.3.2.7 Random Numbers
  ;; 4.3.2.8 Other Randomness Utilities (racket/random)
  ;; 4.3.2.9 Number–String Conversions
@@ -552,6 +553,17 @@ bytes->string/utf-8
   (if (zero? n)
       -1
       (sub1 (integer-length (bitwise-and n (- n))))))
+
+(define random
+  ;; Simple wrapper around Racket's `random` that exposes the same
+  ;; optional argument behaviour to the rest of the system.  The RNG
+  ;; state itself lives in `runtime-wasm.rkt` and is shared across
+  ;; invocations of the Wasm primitive.
+  (let ([rb random])
+    (case-lambda
+      [() (rb)]
+      [(k) (rb k)]
+      [(min max) (rb min max)])))
 
 ; The "real" apply is a macro (due to keyword arguments)
 ; This defines a plain apply as a procedure.

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -4489,10 +4489,86 @@
                         (call $raise-expected-number (local.get $n))
                         (unreachable))))
                   (else
-                   (call $raise-expected-number (local.get $n))
-                   (unreachable))))
+                  (call $raise-expected-number (local.get $n))
+                  (unreachable))))
 
 
+
+        ;; Shared state for the pseudo-random number generator.
+        ;; The initial value is chosen arbitrarily and can be replaced
+        ;; with a fixed seed if reproducibility is needed.
+        (global $random-state (mut i32) (i32.const 0x9E3779B9))
+
+        ;; A simple SplitMix32 generator that produces uniformly
+        ;; distributed 32-bit integers.  It is fast and has a large
+        ;; period, which is sufficient for the primitives implemented
+        ;; here.  The algorithm is the 32-bit variant of the SplitMix
+        ;; step used by multiple languages as an initialization phase
+        ;; for stronger generators.
+        (func $random-u32 (result i32)
+              (local $z i32)
+              (local.set $z (i32.add (global.get $random-state)
+                                     (i32.const 0x9E3779B9)))
+              (global.set $random-state (local.get $z))
+              (local.set $z (i32.xor (local.get $z)
+                                      (i32.shr_u (local.get $z) (i32.const 16))))
+              (local.set $z (i32.mul (local.get $z) (i32.const 0x85EBCA6B)))
+              (local.set $z (i32.xor (local.get $z)
+                                      (i32.shr_u (local.get $z) (i32.const 13))))
+              (local.set $z (i32.mul (local.get $z) (i32.const 0xC2B2AE35)))
+              (local.set $z (i32.xor (local.get $z)
+                                      (i32.shr_u (local.get $z) (i32.const 16))))
+              (local.get $z))
+
+        ;; Implements Racket's `random` primitive.  Dispatches on the
+        ;; number of arguments at runtime and mirrors the host
+        ;; semantics:
+        ;;   - (random)       -> flonum in (0,1)
+        ;;   - (random k)     -> exact integer in [0,k)
+        ;;   - (random min max) -> exact integer in [min,max)
+        (func $random (type $Prim2)
+              (param $a (ref eq)) (param $b (ref eq))
+              (result (ref eq))
+
+              (local $k i32)
+              (local $min i32)
+              (local $max i32)
+              (local $range i32)
+              (local $r i32)
+
+              (if (ref.eq (local.get $a) (global.get $missing))
+                  (then
+                   (local.set $r (call $random-u32))
+                   (struct.new $Flonum
+                                (i32.const 0)
+                                (f64.div
+                                 (f64.add (f64.convert_i32_u (local.get $r))
+                                          (f64.const 1))
+                                 (f64.const 4294967298.0))))
+                  (else
+                   (if (ref.eq (local.get $b) (global.get $missing))
+                       (then
+                        (if (i32.eqz (call $fx?/i32 (local.get $a)))
+                            (then (call $raise-expected-number (local.get $a)) (unreachable)))
+                        (local.set $k ,(Half `(i31.get_s (ref.cast i31ref (local.get $a)))))
+                        (if (i32.le_s (local.get $k) (i32.const 0))
+                            (then (call $raise-argument-error (local.get $a)) (unreachable)))
+                        (local.set $r (i32.rem_u (call $random-u32) (local.get $k)))
+                        (ref.i31 (i32.shl (local.get $r) (i32.const 1))))
+                       (else
+                        (if (i32.eqz (call $fx?/i32 (local.get $a)))
+                            (then (call $raise-expected-number (local.get $a)) (unreachable)))
+                        (if (i32.eqz (call $fx?/i32 (local.get $b)))
+                            (then (call $raise-expected-number (local.get $b)) (unreachable)))
+                        (local.set $min ,(Half `(i31.get_s (ref.cast i31ref (local.get $a)))))
+                        (local.set $max ,(Half `(i31.get_s (ref.cast i31ref (local.get $b)))))
+                        (local.set $range (i32.sub (local.get $max) (local.get $min)))
+                        (if (i32.le_s (local.get $range) (i32.const 0))
+                            (then (call $raise-argument-error (local.get $b)) (unreachable)))
+                        (local.set $r (i32.add (local.get $min)
+                                               (i32.rem_u (call $random-u32)
+                                                          (local.get $range))))
+                        (ref.i31 (i32.shl (local.get $r) (i32.const 1)))))))
 
          ;;;
          ;;;  4.3.4 Fixnums

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -421,6 +421,23 @@
                          (equal? (integer-length -8) 3)
                          (equal? (integer-length 0) 0)))))
 
+        (list "4.3.2.7 Random Numbers"
+              ;; Basic sanity checks for the `random` primitive.  These
+              ;; tests intentionally avoid relying on a particular
+              ;; sequence and instead just validate the ranges and
+              ;; result types.
+              (list
+               (list "random"
+                     (let ([v (random)])
+                       (and (inexact? v) (> v 0.0) (< v 1.0))))
+               (list "random k"
+                     (let ([v (random 5)])
+                       (and (exact-integer? v) (<= 0 v) (< v 5))))
+               (list "random k edge" (= (random 1) 0))
+               (list "random min max"
+                     (let ([v (random -5 5)])
+                       (and (exact-integer? v) (<= -5 v) (< v 5))))))
+
        (list "4.3.2.10 Extra Constants and Functions"
       (list
        (list "degrees->radians"


### PR DESCRIPTION
## Summary
- add `random` primitive with shared RNG
- expose `random` from primitives list and compiler inlining
- cover `random` behavior in tests
- clarify `random` implementation with inline documentation

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b61504fd888322855e6d20b2572348