### PR TITLE
Add document accessors

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -1087,6 +1087,8 @@ var imports = {
     } : new Proxy({}, { get() { throw new Error('DOM not available in this environment'); } }),
     // Document
     'document': hasDOM ? {
+        'document':                 (()                               => document),
+        'head':                     (()                               => document.head),
         'body':                     (()                               => document.body),
         'create-element':           ((local_name)                     => document.createElement(from_fasl(local_name))),
         'create-text-node':         ((fasl_start)                     => document.createTextNode(from_fasl(fasl_start))),
@@ -1139,6 +1141,8 @@ var imports = {
         // 'writeln':                  ((text)                           => document.writeln(from_fasl(text))),
     }
     : { // Node
+        'document'()                 { throw new Error('DOM not available in this environment'); },
+        'head'()                     { throw new Error('DOM not available in this environment'); },
         'body'()                     { throw new Error('DOM not available in this environment'); },
         'create-element'()           { throw new Error('DOM not available in this environment'); },
         'create-text-node'()         { throw new Error('DOM not available in this environment'); },

--- a/dom.ffi
+++ b/dom.ffi
@@ -475,7 +475,17 @@
 ; The various functions in this section are documented here:   
 ;                                                              
 ;     https://developer.mozilla.org/en-US/docs/Web/API/Document
-;                                                               
+;
+
+(define-foreign js-document
+  #:module "document"
+  #:name   "document"
+  (-> () (extern)))
+
+(define-foreign js-document-head
+  #:module "document"
+  #:name   "head"
+  (-> () (extern)))
 
 (define-foreign js-document-body
   #:module "document"


### PR DESCRIPTION
## Summary
- expose global `document` and its `head` element in DOM FFI

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b6cdacf6f08322b098e17747c877c0