### PR TITLE
Add js-var FFI for variable lookup

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -509,6 +509,7 @@ var imports = {
       'encode-uri-component':      ((s) => encodeURIComponent(from_fasl(s))),
       'escape':                    ((s) => escape(from_fasl(s))),
       'unescape':                  ((s) => unescape(from_fasl(s))),
+      'var':                       ((name) => globalThis[from_fasl(name)]),
       'set-property!':             ((obj, key, val) => { obj[from_fasl(key)] = from_fasl(val); }),
       'object':                    (() => Object),
       'function':                  (() => Function),

--- a/standard.ffi
+++ b/standard.ffi
@@ -90,6 +90,11 @@
   #:name   "unescape"
   (-> (string) (extern)))
 
+(define-foreign js-var
+  #:module "standard"
+  #:name   "var"
+  (-> (string) (extern)))
+
 (define-foreign js-set-property!
   #:module "standard"
   #:name   "set-property!"


### PR DESCRIPTION
## Summary
- expose `js-var` in `standard.ffi` for reading global JavaScript variables
- extend assembler runtime to support `js-var`

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 / not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ce2e01708322bd2f6a990150f340