### PR TITLE
Use js-document-head in JSXGraph example

### DIFF
--- a/test/jsxgraph-example.rkt
+++ b/test/jsxgraph-example.rkt
@@ -1,4 +1,4 @@
-(define head (js-eval "document.head"))
+(define head (js-document-head))
 
 (define container (js-create-element "div"))
 (js-set-attribute! container "id" "box")


### PR DESCRIPTION
## Summary
- Use `js-document-head` instead of `js-eval` to access the document head in the JSXGraph example

## Testing
- `raco test test/jsxgraph-example.rkt` *(command not found: raco)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cf0aed1c832293e6885a2e423a58