### PR TITLE
Add js-ref foreign function for property access

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -510,6 +510,7 @@ var imports = {
       'escape':                    ((s) => escape(from_fasl(s))),
       'unescape':                  ((s) => unescape(from_fasl(s))),
       'var':                       ((name) => globalThis[from_fasl(name)]),
+      'ref':                       ((obj, key) => obj[from_fasl(key)]),
       'set-property!':             ((obj, key, val) => { obj[from_fasl(key)] = from_fasl(val); }),
       'object':                    (() => Object),
       'function':                  (() => Function),

--- a/standard.ffi
+++ b/standard.ffi
@@ -95,6 +95,11 @@
   #:name   "var"
   (-> (string) (extern)))
 
+(define-foreign js-ref
+  #:module "standard"
+  #:name   "ref"
+  (-> (extern string/symbol) (extern)))
+
 (define-foreign js-set-property!
   #:module "standard"
   #:name   "set-property!"


### PR DESCRIPTION
## Summary
- expose `js-ref` in standard FFI for accessing JavaScript object properties
- implement `js-ref` handler in assembler runtime

## Testing
- `racket test/test-basics.rkt` *(failed: command not found: racket)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d6b4f4fc8322937ab6dd460ce279