### PR TITLE
Rename js-set-property to js-set!

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -511,7 +511,7 @@ var imports = {
       'unescape':                  ((s) => unescape(from_fasl(s))),
       'var':                       ((name) => globalThis[from_fasl(name)]),
       'ref':                       ((obj, key) => obj[from_fasl(key)]),
-      'set-property!':             ((obj, key, val) => { obj[from_fasl(key)] = from_fasl(val); }),
+      'set!':                      ((obj, key, val) => { obj[from_fasl(key)] = from_fasl(val); }),
       'object':                    (() => Object),
       'function':                  (() => Function),
       'boolean':                   (() => Boolean),

--- a/standard.ffi
+++ b/standard.ffi
@@ -100,9 +100,9 @@
   #:name   "ref"
   (-> (extern string/symbol) (extern)))
 
-(define-foreign js-set-property!
+(define-foreign js-set!
   #:module "standard"
-  #:name   "set-property!"
+  #:name   "set!"
   (-> (extern value value) ()))
 
 ;;;

--- a/test/callback-example.rkt
+++ b/test/callback-example.rkt
@@ -35,11 +35,11 @@
 (define count 0)
 
 (define (update)
-  (js-set-property! (js-get-element-by-id "message")
-                    "textContent"
-                    (string-append "You have pressed the button "
-                                   (number->string count)
-                                   " times")))
+  (js-set! (js-get-element-by-id "message")
+           "textContent"
+           (string-append "You have pressed the button "
+                          (number->string count)
+                          " times")))
 
 (define (on-click _event)
   (js-log count)

--- a/test/plasmademo.rkt
+++ b/test/plasmademo.rkt
@@ -19,7 +19,7 @@
   (define img (js-canvas2d-create-image-data ctx
                                              (exact->inexact width)
                                              (exact->inexact height)))
-  (js-set-property! (js-global-this) "imgData" img)
+  (js-set! (js-global-this) "imgData" img)
   (define data (js-eval "imgData.data"))
   (let loop-y ([y 0])
     (when (< y height)
@@ -35,10 +35,10 @@
           (define g   (clamp (+ c (* 256. (flsin (- ft (* 0.01 fx)))))))
           (define b   (clamp (+ c (* 256. (flcos (- ft (* 2. 0.01 fy)))))))
           (define idx (* 4 (+ (* y width) x)))
-          (js-set-property! data idx r)
-          (js-set-property! data (add1 idx) g)
-          (js-set-property! data (+ idx 2) b)
-          (js-set-property! data (+ idx 3) 255)
+          (js-set! data idx r)
+          (js-set! data (add1 idx) g)
+          (js-set! data (+ idx 2) b)
+          (js-set! data (+ idx 3) 255)
           (loop-x (add1 x))))
       (loop-y (add1 y))))
   (js-canvas2d-put-image-data ctx img 0. 0.


### PR DESCRIPTION
## Summary
- rename `js-set-property` primitive to `js-set!`
- update all uses in assembler mapping and test programs

## Testing
- `raco test test` *(command failed: raco: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6d896e2a083229df085d95dcd26cd