### PR TITLE
feat: expand jsxgraph example with standard ffi

### DIFF
--- a/jsxgraph.md
+++ b/jsxgraph.md
@@ -30,3 +30,41 @@ To use JSXGraph in a web page, include both the stylesheet and the JavaScript li
    ```
 
 These steps load JSXGraph from a CDN and create a board ready for drawing geometric objects.
+
+## Initializing JSXGraph from WebRacket
+
+The `standard.ffi` library exposes JavaScript operations that let WebRacket
+interact with JSXGraph without relying on `js-eval`. The example below mirrors
+the JavaScript snippet above:
+
+```racket
+(define head (js-document-head))
+
+(define container (js-create-element "div"))
+(js-set-attribute! container "id" "box")
+(js-set-attribute! container "class" "jxgbox")
+(js-set-attribute! container "style" "width: 500px; height: 400px;")
+(js-append-child! (js-document-body) container)
+
+(define options
+  (js-object
+   (vector
+    (vector "boundingbox" (vector -5 5 5 -5))
+    (vector "axis" #t))))
+
+
+(define (init-board _)
+  (define jxg (js-var "JXG"))
+  (define jsx (js-ref jxg "JSXGraph"))
+  (define init-fn (js-ref jsx "initBoard"))
+  (js-operator 'call (vector init-fn jsx "box" options)))
+
+(define script (js-create-element "script"))
+(js-set-attribute! script "src" "https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js")
+(js-add-event-listener! script "load" (procedure->external init-board))
+(js-append-child! head script)
+```
+
+This code constructs the board setup using WebRacket primitives, showing how
+`js-var`, `js-ref`, `js-operator`, and related functions remove the need for
+evaluating raw JavaScript strings.

--- a/test/jsxgraph-example.rkt
+++ b/test/jsxgraph-example.rkt
@@ -11,8 +11,18 @@
 (js-set-attribute! link "href" "https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css")
 (js-append-child! head link)
 
+(define options
+  (js-object
+   (vector
+    (vector "boundingbox" (vector -5 5 5 -5))
+    (vector "axis" #t))))
+
+
 (define (init-board _evt)
-  (js-eval "JXG.JSXGraph.initBoard('box', {boundingbox: [-5, 5, 5, -5], axis: true});"))
+  (define jxg (js-var "JXG"))
+  (define jsx (js-ref jxg "JSXGraph"))
+  (define init-fn (js-ref jsx "initBoard"))
+  (js-operator 'call (vector init-fn jsx "box" options)))
 
 (define script (js-create-element "script"))
 (js-set-attribute! script "src" "https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js")


### PR DESCRIPTION
## Summary
- create JSXGraph board using standard.ffi primitives
- document WebRacket integration without js-eval
- streamline board options by removing js-array-of


------
https://chatgpt.com/codex/tasks/task_e_68b6e2a8b81c8322ab1046c2b754bdd7