### PR TITLE
Add js-send FFI and runtime support

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -515,6 +515,7 @@ var imports = {
       'index':                     ((obj, prop) => obj[from_fasl(prop)]),
       'assign':                    ((name, val) => (globalThis[from_fasl(name)] = from_fasl(val))),
       'new':                       ((ctor, args) => new ctor(...(from_fasl(args) || []))),
+      'send':                      ((obj, name, args) => obj[from_fasl(name)](...(from_fasl(args) || []))),
       'throw':                     (exn => { throw from_fasl(exn); }),
       'null':                      (() => null),
       'this':                      (function () { return this; }),

--- a/standard.ffi
+++ b/standard.ffi
@@ -123,6 +123,12 @@
   ;; Pass arguments as a list or vector.
   (-> (extern value) (extern)))
 
+(define-foreign js-send
+  #:module "standard"
+  #:name   "send"
+  ;; Pass arguments as a list or vector.
+  (-> (extern string/symbol value) (extern)))
+
 (define-foreign js-throw
   #:module "standard"
   #:name   "throw"


### PR DESCRIPTION
## Summary
- add `js-send` binding in `standard.ffi`
- implement `js-send` runtime function in `assembler.rkt`

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b6f505ccc08322b4afc5319065156d