### PR TITLE
Add movable points to JSXGraph example

### DIFF
--- a/test/jsxgraph-example.rkt
+++ b/test/jsxgraph-example.rkt
@@ -23,8 +23,15 @@
 (define (init-board _evt)
   ; The JXG.JSXGraph singleton stores all properties required to load, save, create and free a board.
   (define JSXGraph (dot (js-var "JXG") "JSXGraph"))
-  (js-send JSXGraph "initBoard" (vector "box" (js-object '#[#["boundingbox" #[-5 5 5 -5]]
-                                                            #["axis"        #t]]))))
+  (define board
+    (js-send JSXGraph "initBoard" (vector "box" (js-object '#[#["boundingbox" #[-5 5 5 -5]]
+                                                              #["axis"        #t]]))))
+  (js-send board "create"
+           (vector "point" (vector -2 1)
+                   (js-object '#[#["name" "A"]])))
+  (js-send board "create"
+           (vector "point" (vector 2 -1)
+                   (js-object '#[#["name" "B"]])))
 
 (define script (js-create-element "script"))
 (js-set-attribute!      script "src"  "https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js")


### PR DESCRIPTION
## Summary
- capture board from `initBoard`
- add two named, draggable points to the JSXGraph demo

## Testing
- `raco test test/jsxgraph-example.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fdc179188322bcb24f6853014df5