### PR TITLE
Add triangle and line to JSXGraph example

### DIFF
--- a/test/jsxgraph-example.rkt
+++ b/test/jsxgraph-example.rkt
@@ -30,15 +30,43 @@
   (define board
     (js-send JSXGraph "initBoard" (vector "box" (js-object '#[#["boundingbox" #[-5 5 5 -5]]
                                                               #["axis"        #t]]))))
-  (js-send* board "create"
-            "point"                           ; element type
-            (vector -2 1)                     ; array of parents
-            (js-object '#[#["name" "A"]]))    ; attributes
+  (define A
+    (js-send* board "create"
+              "point"                           ; element type
+              (vector -2 1)                     ; array of parents
+              (js-object '#[#["name" "A"]])))   ; attributes
+
+  (define B
+    (js-send* board "create"
+              "point"                           ; element type
+              (vector 3 4)                      ; array of parents
+              (js-object '#[#["name" "B"]])))   ; attributes
+
+  (define C
+    (js-send* board "create"
+              "point"
+              (vector 1 -2)
+              (js-object '#[#["name" "C"]])))   ; attributes
 
   (js-send* board "create"
-            "point"                           ; element type
-            (vector 3 4)                      ; array of parents
-            (js-object '#[#["name" "B"]]))    ; attributes
+            "line"
+            (vector A B)
+            (js-object '#[]))
+
+  (js-send* board "create"
+            "segment"
+            (vector A B)
+            (js-object '#[]))
+
+  (js-send* board "create"
+            "segment"
+            (vector B C)
+            (js-object '#[]))
+
+  (js-send* board "create"
+            "segment"
+            (vector C A)
+            (js-object '#[]))
   )
 
 (define script (js-create-element "script"))


### PR DESCRIPTION
## Summary
- add point C in JSXGraph board
- draw line through points A and B
- connect points A, B, and C with segments

## Testing
- `raco test test/jsxgraph-example.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7015aea388322b320d0804ea639f0