### PR TITLE
Draw perpendicular from A to BC in JSXGraph example

### DIFF
--- a/test/jsxgraph-example.rkt
+++ b/test/jsxgraph-example.rkt
@@ -58,6 +58,12 @@
             (vector A B)
             (js-object '#[]))
 
+  (define BC
+    (js-send* board "create"
+              "line"
+              (vector B C)
+              (js-object '#[#["visible" #f]])))
+
   (js-send* board "create"
             "segment"
             (vector B C)
@@ -67,6 +73,18 @@
             "segment"
             (vector C A)
             (js-object '#[]))
+
+  (define l
+    (js-send* board "create"
+              "perpendicular"
+              (vector BC A)
+              (js-object '#[#["name" "l"]])))
+
+  (define P
+    (js-send* board "create"
+              "intersection"
+              (vector l BC)
+              (js-object '#[#["name" "P"]])))
   )
 
 (define script (js-create-element "script"))


### PR DESCRIPTION
## Summary
- Extend example to construct a line through A perpendicular to BC
- Add intersection point P where the perpendicular meets BC

## Testing
- `racket test/jsxgraph-example.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b702d565848322bf449dfe6ecb58a3