### PR TITLE
Make + variadic

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3068,8 +3068,9 @@
             [(1)   (first aes)]
             [else  `(array.new_fixed $Values ,n ,@aes)])]
 
-         ;;; Standard Inlining         
-         [(s-exp->fasl) ; 1 to 2 arguments (in the keyword-less version in "core.rkt"
+        ;;; Standard Inlining
+        [(+)                         (inline-prim/variadic sym ae1 0)]
+        [(s-exp->fasl) ; 1 to 2 arguments (in the keyword-less version in "core.rkt"
           (inline-prim/optional sym ae1 1 2)]
          [(fasl->s-exp)                (inline-prim/fixed sym ae1 1)]
 
@@ -3246,14 +3247,14 @@
          [else
           (match (length ae1)
             [0 (case sym
-                 [(+ -)      '(global.get $zero)]
+                 [(-)        '(global.get $zero)]
                  [(fx+ fx-)  '(global.get $zero)]
                  [(fl+ fl-)  '(global.get $flzero)]
                  [(* fx*)    '(global.get $one)]
                  [(fl*)      '(global.get $flone)]
                  [else       `(call ,(Prim pr))])]
             [1 (case sym
-                 [(  +   *)  (AExpr (first ae1))]
+                 [(*)        (AExpr (first ae1))]
                  [(fx+ fx*)  (AExpr (first ae1))]
                  [(fl+ fl*)  (AExpr (first ae1))]
                  [(fx-)      `(call ,(Prim pr) (global.get $zero)   ,(AExpr (first ae1)))]
@@ -3262,17 +3263,17 @@
                  [(fl/)      `(call ,(Prim pr) (global.get $flone)  ,(AExpr (first ae1)))]
                  [else       `(call ,(Prim pr)                      ,(AExpr (first ae1)))])]
             [2 (case sym
-                 [(+ - *)       `(call ,(Prim pr)
+                 [(- *)         `(call ,(Prim pr)
                                        ,(AExpr (first ae1)) ,(AExpr (second ae1)))]
                  [(fx+ fx- fx*) `(call ,(Prim pr)
-                                       ,(AExpr (first ae1)) ,(AExpr (second ae1)))]                                           
+                                      ,(AExpr (first ae1)) ,(AExpr (second ae1)))]
                  [(fl+ fl- fl*) `(call ,(Prim pr)
-                                       ,(AExpr (first ae1)) ,(AExpr (second ae1)))]
+                                      ,(AExpr (first ae1)) ,(AExpr (second ae1)))]
                  ; / needs to signal an Racket error if denominator is zero
                  [else   `(call ,(Prim pr)
                                 ,(AExpr (first ae1)) ,(AExpr (second ae1)))])]
             [_ (case sym
-                 [(+ fx+ fl+
+                 [(fx+ fl+
                      * fx* fl*
                      - fx- fl-) ; (+ a b c ...) = (+ (+ a b) c ...)
                   (let loop ([aes (AExpr* ae1)])

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -232,8 +232,8 @@
        (list "4.3.2.1 Arithmetic"
              (list
               (list "+"
-                    (and #;(equal? (+) 0)
-                         #;(equal? (+ 1) 1)
+                    (and (equal? (+) 0)
+                         (equal? (+ 1) 1)
                          (equal? (+ 1  2)  3)
                          (equal? (+ 1. 2)  3.)
                          (equal? (+ 1  2.) 3.)


### PR DESCRIPTION
## Summary
- support variadic `+` at runtime
- compile `+` calls as variadic instead of nested binary ops
- exercise zero and single-argument `+` in basic tests

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73a8c24f483228389c89cd86105c5