### PR TITLE
Add cons? and empty? primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -406,7 +406,7 @@
   bytes             ; used in datum construction
   string            ; used in datum construction
 
-  pair? null? 
+  pair? cons? null? empty?
   cons car cdr
   list              ; not first order yet
   list? length list-ref list-tail

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -297,12 +297,14 @@ bytes->string/utf-8
  keyword->immutable-string
  
  
- ;; 4.10 Pairs and Lists
- pair?
- null?
- cons
- car
- cdr
+  ;; 4.10 Pairs and Lists
+  pair?
+  cons?
+  null?
+  empty?
+  cons
+  car
+  cdr
  list?
  list
  list*

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -9531,15 +9531,21 @@
          (func $raise-bad-list-ref-index
                (param $xs  (ref $Pair)) (param $i   i32) (param $len i32)
                (unreachable))
-         (func $pair? (type $Prim1) (param $v (ref eq)) (result (ref eq))
-               (if (result (ref eq)) (ref.test (ref $Pair) (local.get $v))
-                   (then (global.get $true))
-                   (else (global.get $false))))
+          (func $pair? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+                (if (result (ref eq)) (ref.test (ref $Pair) (local.get $v))
+                    (then (global.get $true))
+                    (else (global.get $false))))
 
-         (func $null? (type $Prim1) (param $v (ref eq)) (result (ref eq))
-               (if (result (ref eq)) (ref.eq (local.get $v) (global.get $null))
-                   (then (global.get $true))
-                   (else (global.get $false))))
+          (func $cons? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+                (call $pair? (local.get $v)))
+
+          (func $null? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+                (if (result (ref eq)) (ref.eq (local.get $v) (global.get $null))
+                    (then (global.get $true))
+                    (else (global.get $false))))
+
+          (func $empty? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+                (call $null? (local.get $v)))
 
          (func $cons (type $Prim2) (param $a (ref eq)) (param $d (ref eq)) (result (ref eq))
                (struct.new $Pair (i32.const 0) (local.get $a) (local.get $d)))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1084,8 +1084,18 @@
 
                    #;(equal? (procedure-arity keyword<?) 2)))))
 
- (list "4.10 Pairs and Lists"
+(list "4.10 Pairs and Lists"
        (list
+        (list
+         "cons?"
+         (and (equal? (cons? '(1 2)) #t)
+              (equal? (cons? '())   #f)
+              (equal? (procedure-arity cons?) 1)))
+        (list
+         "empty?"
+         (and (equal? (empty? '(1 2)) #f)
+              (equal? (empty? '())   #t)
+              (equal? (procedure-arity empty?) 1)))
         (list
          "append"
          (and (equal? (append)                         '())


### PR DESCRIPTION
## Summary
- add `cons?` and `empty?` runtime predicates
- expose new predicates in primitive lists and compiler
- cover `cons?` and `empty?` with basic tests

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73b4e75188322b4696631cf2ca1fc