### PR TITLE
Add last and last-pair list primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -410,7 +410,7 @@
   cons car cdr
   list              ; not first order yet
   list? length list-ref list-tail
-  first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth
+  first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth last last-pair
   append ; variadic list primitive
   reverse memq
   alt-reverse ; used in expansion of for/list

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -326,11 +326,13 @@ bytes->string/utf-8
  tenth
  eleventh
  twelfth
- thirteenth
- fourteenth
- fifteenth
- append
- reverse
+  thirteenth
+  fourteenth
+  fifteenth
+  last
+  last-pair
+  append
+  reverse
 
  map
  ; andmap

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -9719,7 +9719,36 @@
                    ;; Retrieve element using list-ref
                    (call $list-ref
                          (local.get $xs)
-                         (ref.i31 (i32.shl (i32.const ,idx) (i32.const 1))))))
+                        (ref.i31 (i32.shl (i32.const ,idx) (i32.const 1))))))
+
+        ;; last-pair/checked: takes a Pair and returns the last Pair in the chain
+        (func $last-pair/checked (param $p (ref $Pair)) (result (ref $Pair))
+              (local $node (ref $Pair))
+              (local $next (ref eq))
+              (local.set $node (local.get $p))
+              (loop $loop
+                    (local.set $next (struct.get $Pair $d (local.get $node)))
+                    (if (ref.test (ref $Pair) (local.get $next))
+                        (then (local.set $node (ref.cast (ref $Pair) (local.get $next)))
+                              (br $loop))
+                        (else (return (local.get $node)))))
+
+        (func $last (type $Prim1) (param $xs (ref eq)) (result (ref eq))
+              (local $p (ref $Pair))
+              ;; Type check: non-empty proper list
+              (if (ref.eq (local.get $xs) (global.get $null))
+                  (then (call $raise-argument-error (local.get $xs)) (unreachable)))
+              (if (ref.eq (call $list? (local.get $xs)) (global.get $false))
+                  (then (call $raise-argument-error (local.get $xs)) (unreachable)))
+              ;; Retrieve last element
+              (local.set $p (call $last-pair/checked (ref.cast (ref $Pair) (local.get $xs))))
+              (struct.get $Pair $a (local.get $p)))
+
+        (func $last-pair (type $Prim1) (param $xs (ref eq)) (result (ref eq))
+              ;; Type check: pair?
+              (if (ref.test (ref $Pair) (local.get $xs))
+                  (then (call $last-pair/checked (ref.cast (ref $Pair) (local.get $xs))))
+                  (else (call $raise-pair-expected (local.get $xs)) (unreachable))))
 
         ;; list-tail/checked: xs is known to be a Pair and i > 0.
          ;; Returns the result of cdr^i(xs). Works with improper lists:

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1186,6 +1186,14 @@
               (and (equal? (fifteenth '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)) 15)
                    (equal? (procedure-arity fifteenth) 1)))
 
+        (list "last"
+              (and (equal? (last '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)) 15)
+                   (equal? (procedure-arity last) 1)))
+        (list "last-pair"
+              (and (equal? (last-pair '(1 2 3 4)) '(4))
+                   (equal? (last-pair '(1 2 3 . 4)) '(3 . 4))
+                   (equal? (procedure-arity last-pair) 1)))
+
         (list "list*"
               (and (equal? (list* 1 2 3) (cons 1 (cons 2 3)))
                    (equal? (list* 1 2 (list 3 4)) '(1 2 3 4))))


### PR DESCRIPTION
## Summary
- implement `last` and `last-pair` in the WebAssembly runtime
- expose `last` and `last-pair` as primitives and compiler targets
- cover `last` and `last-pair` behaviors with baseline tests

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7427f0f2883229c145fdbbdd66074