### PR TITLE
Add ormap primitive and tests

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3099,6 +3099,7 @@
          [(log)                        (inline-prim/optional sym ae1 1 2)]
          ; Todo: map and for-each needs to check that the first argument is a procedure
          [(map)                        (inline-prim/variadic sym ae1 2 1)]
+         [(ormap)                      (inline-prim/variadic sym ae1 2 1)]
          [(for-each)                   (inline-prim/variadic sym ae1 2 1)]
 
          [(hash-ref)                   (inline-prim/optional sym ae1 2 3)]

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -334,7 +334,7 @@ bytes->string/utf-8
 
  map
  ; andmap
- ; ormap
+ ormap
  for-each
  ; foldl
  ; foldr

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -10200,6 +10200,142 @@
                (unreachable))
 
 
+
+         (func $ormap (type $Prim>=1)
+               (param $proc (ref eq))   ;; procedure
+               (param $xss  (ref eq))   ;; list of lists
+               (result      (ref eq))
+
+               (local $f      (ref $Procedure))
+               (local $finv   (ref $ProcedureInvoker))
+               (local $outer  (ref eq))
+               (local $pair   (ref $Pair))
+               (local $elem   (ref eq))
+               (local $nlists i32)
+
+               (local $lists  (ref $Args))  ;; cursors for each list
+               (local $call   (ref $Args))  ;; args for f (length = nlists)
+               (local $i      i32)
+               (local $cur    (ref eq))
+               (local $stop   i32)
+               (local $r      (ref eq))
+
+               ;; 1) Check that $proc is a procedure and fetch its invoker
+               (if (i32.eqz (ref.test (ref $Procedure) (local.get $proc)))
+                   (then (call $raise-argument-error:procedure-expected (local.get $proc))
+                         (unreachable)))
+               (local.set $f    (ref.cast (ref $Procedure) (local.get $proc)))
+               (local.set $finv (struct.get $Procedure $invoke (local.get $f)))
+
+               ;; 2) Walk outer list xss to count #lists; ensure xss is proper and each element is a list head
+               (local.set $nlists (i32.const 0))
+               (local.set $outer  (local.get $xss))
+               (block $count_done
+                      (loop $count
+                            (if (ref.eq (local.get $outer) (global.get $null))
+                                (then (br $count_done)))
+                            (if (i32.eqz (ref.test (ref $Pair) (local.get $outer)))
+                                (then (call $raise-pair-expected (local.get $outer)) (unreachable)))
+                            (local.set $pair (ref.cast (ref $Pair) (local.get $outer)))
+                            (local.set $elem (struct.get $Pair $a (local.get $pair)))
+                            (if (i32.eqz
+                                 (i32.or
+                                  (ref.eq (local.get $elem) (global.get $null))
+                                  (ref.test (ref $Pair) (local.get $elem))))
+                                (then (call $raise-pair-expected (local.get $elem)) (unreachable)))
+                            (local.set $nlists (i32.add (local.get $nlists) (i32.const 1)))
+                            (local.set $outer (struct.get $Pair $d (local.get $pair)))
+                            (br $count)))
+
+               ;; Racket's ormap requires at least one list argument
+               (if (i32.eq (local.get $nlists) (i32.const 0))
+                   (then (call $raise-arity-mismatch) (unreachable)))
+
+               ;; 3) Allocate arrays for list cursors and call arguments; seed list cursors from xss
+               (local.set $lists (array.new $Args (global.get $null) (local.get $nlists)))
+               (local.set $call  (array.new $Args (global.get $null) (local.get $nlists)))
+
+               (local.set $outer (local.get $xss))
+               (local.set $i (i32.const 0))
+               (block $seed_done
+                      (loop $seed
+                            (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                (then (br $seed_done)))
+                            (local.set $pair (ref.cast (ref $Pair) (local.get $outer)))
+                            (local.set $elem (struct.get $Pair $a (local.get $pair)))
+                            (array.set $Args (local.get $lists) (local.get $i) (local.get $elem))
+                            (local.set $outer (struct.get $Pair $d (local.get $pair)))
+                            (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                            (br $seed)))
+
+               ;; 4) Main loop: stop at the shortest list or when f returns truthy
+               (loop $loop
+                     ;; (a) Check state of all lists; determine if we stop
+                     (local.set $stop (i32.const 0))
+                     (local.set $i (i32.const 0))
+                     (block $check_done
+                            (loop $check
+                                  (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                      (then (br $check_done)))
+                                  (local.set $cur (array.get $Args (local.get $lists) (local.get $i)))
+                                  (if (ref.eq (local.get $cur) (global.get $null))
+                                      (then (local.set $stop (i32.const 1)))
+                                      (else
+                                       (if (i32.eqz (ref.test (ref $Pair) (local.get $cur)))
+                                           (then (call $raise-pair-expected (local.get $cur))
+                                                 (unreachable)))))
+                                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                                  (br $check)))
+
+                     ;; If any list is empty → return #f
+                     (if (i32.ne (local.get $stop) (i32.const 0))
+                         (then (return (global.get $false))))
+
+                     ;; (b) Build call args for f: cars of each list
+                     (local.set $i (i32.const 0))
+                     (block $cars_done
+                            (loop $cars
+                                  (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                      (then (br $cars_done)))
+                                  (local.set $pair
+                                             (ref.cast (ref $Pair)
+                                                       (array.get $Args (local.get $lists) (local.get $i))))
+                                  (array.set $Args
+                                             (local.get $call) (local.get $i)
+                                             (struct.get $Pair $a (local.get $pair)))
+                                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                                  (br $cars)))
+
+                     ;; (c) Apply f to those cars
+                     (local.set $r
+                                (call_ref $ProcedureInvoker
+                                          (local.get $f)
+                                          (local.get $call)
+                                          (local.get $finv)))
+
+                     ;; (d) If result is not #f, return it
+                     (if (ref.eq (local.get $r) (global.get $false))
+                         (then (nop))
+                         (else (return (local.get $r))))
+
+                     ;; (e) Advance each list (cdr)
+                     (local.set $i (i32.const 0))
+                     (block $cdrs_done
+                            (loop $cdrs
+                                  (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                      (then (br $cdrs_done)))
+                                  (local.set $pair
+                                             (ref.cast (ref $Pair)
+                                                       (array.get $Args (local.get $lists) (local.get $i))))
+                                  (array.set $Args
+                                             (local.get $lists) (local.get $i)
+                                             (struct.get $Pair $d (local.get $pair)))
+                                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                                  (br $cdrs)))
+
+                     (br $loop))
+               (unreachable))
+
          (func $for-each (type $Prim>=1)
                (param $proc (ref eq))   ;; procedure
                (param $xss  (ref eq))   ;; list of lists

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1196,6 +1196,13 @@
               (and (equal? (filter (λ (x) (positive? x)) '(1 -2 3 4 -5)) '(1 3 4))
                    (equal? (filter (λ (x) (positive? x)) '()) '())))
 
+        (list "ormap"
+              (and (equal? (ormap eq? '(a b c) '(a b c)) #t)
+                   (equal? (ormap positive? '(1 2 a)) #t)
+                   (equal? (ormap positive? '(-1 -2 -3)) #f)
+                   (equal? (ormap + '(1 2 3) '(4 5 6)) 5)
+                   (equal? (ormap positive? '()) #f)))
+
         (list "build-list"
               (and (equal? (build-list 10 values)
                            '(0 1 2 3 4 5 6 7 8 9))


### PR DESCRIPTION
## Summary
- implement `ormap` in the WebAssembly runtime with short-circuiting behavior
- expose `ormap` as a primitive and compiler inline target
- add regression tests covering `ormap`

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y racket` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7436434d88322aa79099bb67dd629