### PR TITLE
Make multiplication variadic

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3072,6 +3072,7 @@
 
         ;;; Standard Inlining
         [(+)                         (inline-prim/variadic sym ae1 0)]
+        [(*)                         (inline-prim/variadic sym ae1 0)]
         [(-)                         (inline-prim/variadic sym ae1 1)]
         [(s-exp->fasl) ; 1 to 2 arguments (in the keyword-less version in "core.rkt"
           (inline-prim/optional sym ae1 1 2)]
@@ -3254,11 +3255,10 @@
                  [(-)        '(global.get $zero)]
                  [(fx+ fx-)  '(global.get $zero)]
                  [(fl+ fl-)  '(global.get $flzero)]
-                 [(* fx*)    '(global.get $one)]
+                 [(fx*)      '(global.get $one)]
                  [(fl*)      '(global.get $flone)]
                  [else       `(call ,(Prim pr))])]
             [1 (case sym
-                 [(*)        (AExpr (first ae1))]
                  [(fx+ fx*)  (AExpr (first ae1))]
                  [(fl+ fl*)  (AExpr (first ae1))]
                  [(fx-)      `(call ,(Prim pr) (global.get $zero)   ,(AExpr (first ae1)))]
@@ -3267,7 +3267,7 @@
                  [(fl/)      `(call ,(Prim pr) (global.get $flone)  ,(AExpr (first ae1)))]
                  [else       `(call ,(Prim pr)                      ,(AExpr (first ae1)))])]
             [2 (case sym
-                 [(- *)         `(call ,(Prim pr)
+                 [(-)           `(call ,(Prim pr)
                                        ,(AExpr (first ae1)) ,(AExpr (second ae1)))]
                  [(fx+ fx- fx*) `(call ,(Prim pr)
                                       ,(AExpr (first ae1)) ,(AExpr (second ae1)))]
@@ -3278,7 +3278,7 @@
                                 ,(AExpr (first ae1)) ,(AExpr (second ae1)))])]
             [_ (case sym
                  [(fx+ fl+
-                     * fx* fl*
+                     fx* fl*
                      - fx- fl-) ; (+ a b c ...) = (+ (+ a b) c ...)
                   (let loop ([aes (AExpr* ae1)])
                     (match aes

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -4113,9 +4113,9 @@
                                           (unreachable)))))))
             (list (binop '$+/2 '$fx+ '$fl+)
                   (binop '$-/2 '$fx- '$fl-)
-                  (binop '$* '$fx* '$fl*)))
+                  (binop '$*/2 '$fx* '$fl*)))
 
-         (func $+ (type $Prim>=0)
+        (func $+ (type $Prim>=0)
                (param $xs0 (ref eq)) (result (ref eq))
 
                (local $xs   (ref eq))
@@ -4141,7 +4141,36 @@
                             (br $loop)))
               (local.get $r))
 
-         (func $- (type $Prim>=1)
+        (func $* (type $Prim>=0)
+               (param $xs0 (ref eq)) (result (ref eq))
+
+               (local $xs   (ref eq))
+               (local $node (ref $Pair))
+               (local $v    (ref eq))
+               (local $r    (ref eq))
+
+               (local.set $xs
+                          (if (result (ref eq))
+                              (ref.test (ref $Args) (local.get $xs0))
+                              (then (call $rest-arguments->list
+                                          (ref.cast (ref $Args) (local.get $xs0))
+                                          (i32.const 0)))
+                              (else (local.get $xs0))))
+               (local.set $r (global.get $one))
+               (block $done
+                      (loop $loop
+                            (br_if $done (ref.eq (local.get $xs) (global.get $null)))
+                            (local.set $node (ref.cast (ref $Pair) (local.get $xs)))
+                            (local.set $v    (struct.get $Pair $a (local.get $node)))
+                            (if (ref.eq (call $fxzero? (local.get $v)) (global.get $true))
+                                (then (local.set $r (global.get $zero))
+                                      (br $done))
+                                (else (local.set $r (call $*/2 (local.get $r) (local.get $v)))))
+                            (local.set $xs   (struct.get $Pair $d (local.get $node)))
+                            (br $loop)))
+              (local.get $r))
+
+        (func $- (type $Prim>=1)
                (param $a1   (ref eq))
                (param $rest (ref eq))
                (result      (ref eq))
@@ -4296,7 +4325,7 @@
                              ;; general case: lcm(n,m) = (n / gcd(n,m)) * m
                              (else (block (result (ref eq))
                                           (local.set $g (call $gcd/2 (local.get $n) (local.get $m)))
-                                          (call $*
+                                          (call $*/2
                                                 (if (result (ref eq))
                                                     (i32.and (call $fx?/i32 (local.get $n))
                                                              (call $fx?/i32 (local.get $g)))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -246,12 +246,14 @@
                          (equal? (- 5. 2.)  3.)
                          (equal? (- 5 2 1)  2)))
               (list "*"
-                    (and #;(equal? (*) 1)
-                         #;(equal? (* 2) 2)
+                    (and (equal? (*)        1)
+                         (equal? (* 2)      2)
                          (equal? (* 2  3)   6)
+                         (equal? (* 2  3 4) 24)
                          (equal? (* 2. 3)   6.)
                          (equal? (* 2  3.)  6.)
-                         (equal? (* 2. 3.)  6.)))
+                         (equal? (* 2. 3.)  6.)
+                         (equal? (* 0 8.0)  0)))
               (list "/"
                     (and (equal? (/ 10  2)  5)
                          (equal? (/ 10. 2)  5.)


### PR DESCRIPTION
## Summary
- Support variadic multiplication in the runtime with early exact-zero handling
- Update compiler inlining to target the new variadic implementation
- Align multiplication behaviour with other numeric primitives

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74bc5a68c8322935acdcb57be0fd9