### PR TITLE
Add list remove primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -416,7 +416,7 @@
   alt-reverse ; used in expansion of for/list
   map andmap ormap for-each
   list*
-  filter
+  filter remove
   make-list
   build-list
 
@@ -3104,6 +3104,8 @@
          [(andmap)                     (inline-prim/variadic sym ae1 2 1)]
          [(ormap)                      (inline-prim/variadic sym ae1 2 1)]
          [(for-each)                   (inline-prim/variadic sym ae1 2 1)]
+
+         [(remove)                     (inline-prim/optional sym ae1 2 3)]
 
          [(hash-ref)                   (inline-prim/optional sym ae1 2 3)]
         [(random)                      (inline-prim/optional sym ae1 0 2)]

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -343,7 +343,7 @@ for-each
  ; foldr
 
  filter
- ; remove
+ remove
  ; remq
  ; remv
  ; remw

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -10738,6 +10738,88 @@
                      (br $loop))
                (unreachable))
 
+         (func $remove (type $Prim3)
+               (param $v    (ref eq))   ;; value to remove
+               (param $lst  (ref eq))   ;; list
+               (param $proc (ref eq))   ;; optional comparator
+               (result      (ref eq))
+
+               (local $f       (ref $Procedure))
+               (local $finv    (ref $ProcedureInvoker))
+               (local $call    (ref $Args))
+               (local $cur     (ref eq))
+               (local $pair    (ref $Pair))
+               (local $elem    (ref eq))
+               (local $acc     (ref eq))
+               (local $res     (ref eq))
+               (local $r       (ref eq))
+               (local $tail    (ref eq))
+               (local $use-proc i32)
+
+               ;; 1) Handle optional comparator
+               (if (ref.eq (local.get $proc) (global.get $missing))
+                   (then (local.set $use-proc (i32.const 0)))
+                   (else
+                    (if (i32.eqz (ref.test (ref $Procedure) (local.get $proc)))
+                        (then (call $raise-argument-error:procedure-expected (local.get $proc))
+                              (unreachable)))
+                    (local.set $f    (ref.cast (ref $Procedure) (local.get $proc)))
+                    (local.set $finv (struct.get $Procedure $invoke (local.get $f)))
+                    (local.set $call (array.new $Args (global.get $null) (i32.const 2)))
+                    (local.set $use-proc (i32.const 1))))
+
+               ;; 2) Iterate through list until match found
+               (local.set $cur (local.get $lst))
+               (local.set $acc (global.get $null))
+               (loop $loop
+                     (if (ref.eq (local.get $cur) (global.get $null))
+                         (then (return (local.get $lst))))
+                     (if (i32.eqz (ref.test (ref $Pair) (local.get $cur)))
+                         (then (call $raise-pair-expected (local.get $cur))
+                               (unreachable)))
+                     (local.set $pair (ref.cast (ref $Pair) (local.get $cur)))
+                     (local.set $elem (struct.get $Pair $a (local.get $pair)))
+                     (local.set $tail (struct.get $Pair $d (local.get $pair)))
+                     (block $found
+                            (if (i32.eqz (local.get $use-proc))
+                                (then
+                                 (if (ref.eq (call $equal? (local.get $v) (local.get $elem))
+                                              (global.get $false))
+                                     (then
+                                      (local.set $acc (call $cons (local.get $elem) (local.get $acc)))
+                                      (local.set $cur (local.get $tail))
+                                      (br $loop))
+                                     (else (br $found))))
+                                (else
+                                 (array.set $Args (local.get $call) (i32.const 0) (local.get $v))
+                                 (array.set $Args (local.get $call) (i32.const 1) (local.get $elem))
+                                 (local.set $r
+                                            (call_ref $ProcedureInvoker
+                                                      (local.get $f)
+                                                      (local.get $call)
+                                                      (local.get $finv)))
+                                 (if (ref.eq (local.get $r) (global.get $false))
+                                     (then
+                                      (local.set $acc (call $cons (local.get $elem) (local.get $acc)))
+                                      (local.set $cur (local.get $tail))
+                                      (br $loop))
+                                     (else (br $found)))))
+
+                            ;; found match, fallthrough
+                            )
+                     (local.set $cur (local.get $tail))
+                     (local.set $res (local.get $cur))
+                     (local.set $cur (local.get $acc))
+                     (loop $rev
+                           (if (ref.eq (local.get $cur) (global.get $null))
+                               (then (return (local.get $res))))
+                           (local.set $pair (ref.cast (ref $Pair) (local.get $cur)))
+                           (local.set $res (call $cons (struct.get $Pair $a (local.get $pair))
+                                                     (local.get $res)))
+                           (local.set $cur (struct.get $Pair $d (local.get $pair)))
+                           (br $rev)))
+               (unreachable))
+
 
 
          ;;;

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1220,6 +1220,16 @@
               (and (equal? (filter (λ (x) (positive? x)) '(1 -2 3 4 -5)) '(1 3 4))
                    (equal? (filter (λ (x) (positive? x)) '()) '())))
 
+        (list "remove"
+              (and (equal? (remove 2 (list 1 2 3 2 4)) '(1 3 2 4))
+                   (equal? (remove '(2) (list '(1) '(2) '(3))) '((1) (3)))
+                   (equal? (remove "2" (list "1" "2" "3")) '("1" "3"))
+                   (equal? (remove #\c (list #\a #\b #\c)) '(#\a #\b))
+                   (equal? (remove "B" (list "a" "A" "b" "B") string-ci=?) '("a" "A" "B"))
+                   (let ([lst (list 1 2 3 2 4)])
+                     (and (eq? (remove 5 lst) lst)
+                          (equal? (remove 5 lst) lst)))))
+
         (list "andmap"
               (and (equal? (andmap eq? '(a b c) '(a b c)) #t)
                    (equal? (andmap positive? '(1 2 3)) #t)


### PR DESCRIPTION
## Summary
- implement list `remove` with optional comparator in wasm runtime
- wire `remove` into primitive lists and compiler
- cover `remove` behaviour with new tests

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7516e1c148322ad6905f46390710e