### PR TITLE
Add external-number->flonum primitive

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -481,6 +481,10 @@ var imports = {
       }),
       'register_external': (obj => { externals.push(obj); return externals.length - 1; }),
       'lookup_external':   (idx => externals[idx]),
+      'external_number_to_f64': (obj =>
+        (typeof obj === 'number'
+         ? obj
+         : (obj instanceof Number ? obj.valueOf() : NaN))),
       'char_upcase': ((cp) => {
         const s = String.fromCodePoint(cp).toUpperCase();
         const arr = Array.from(s);

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -629,6 +629,7 @@
   ; grow-vector
   ; shrink-vector
 
+  external-number->flonum
   external?
   )
 

--- a/priminfo.rkt
+++ b/priminfo.rkt
@@ -62,6 +62,7 @@
     raise-unbound-variable-reference ; used for unbound variables outside modules
     js-log
     procedure->external
+    external-number->flonum
     ))
 
 

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -442,6 +442,7 @@ for-each
  s-exp->fasl
  fasl->s-exp
  procedure->external
+ external-number->flonum
  js_log
  external?
 
@@ -454,6 +455,10 @@ for-each
   (unless (procedure? p)
     (raise-argument-error 'procedure->external "procedure?" p))
   p)
+
+(define (external-number->flonum x)
+  (cond [(number? x) (exact->inexact x)]
+        [else (raise-argument-error 'external-number->flonum "number?" x)]))
 
 
 ;; Changed in version 8.15.0.7: Added string-find.

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1397,9 +1397,18 @@
 
         (list "eq-hash-code"
               (and (let ([xs (list 1 2 3)]
-                         [ys (list 1 2 4)])                         
+                         [ys (list 1 2 4)])
                      (and      (eq? (eq-hash-code xs) (eq-hash-code xs))
                           (not (eq? (eq-hash-code xs) (eq-hash-code ys)))))))
 
-        )))
+        )
+
+ (list "FFI"
+       (list
+        (list "external-number->flonum"
+              (let ([e (js-eval "new Number(42)")])
+                (equal? (external-number->flonum e) 42.0))))
+       )
+
+ )
 


### PR DESCRIPTION
## Summary
- support conversion from external JavaScript numbers to WebRacket $Flonum via new primitive `$external-number->flonum`
- expose and stub `external-number->flonum` primitive in compiler and Racket-side primitives
- provide JavaScript host implementation and basic test case

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82627ff24832294866a83b8b7c6eb