### PR TITLE
Refactor vector-map via shared template

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -11545,117 +11545,30 @@
                (return (local.get $xs)))
 
         (func $vector-map (type $Prim>=1)
-              (param $proc  (ref eq))
-              (param $vecs  (ref eq))
-              (result       (ref eq))
+              (param $proc (ref eq))
+              (param $vecs (ref eq))
+              (result (ref eq))
 
-              (local $f      (ref $Procedure))
-              (local $finv   (ref $ProcedureInvoker))
-              (local $cur    (ref eq))
-              (local $pair   (ref $Pair))
-              (local $vec    (ref $Vector))
-              (local $vectors (ref $Args))
-              (local $call   (ref $Args))
-              (local $res    (ref $Array))
-              (local $nvecs  i32)
-              (local $len    i32)
-              (local $i      i32)
-              (local $j      i32)
-              (local $elem   (ref eq))
-              (local $r      (ref eq))
+              (local $pair (ref $Pair))
+              (local $v0   (ref eq))
+              (local $rest (ref eq))
 
-              ;; 1) Validate procedure
-              (if (i32.eqz (ref.test (ref $Procedure) (local.get $proc)))
-                  (then (call $raise-argument-error:procedure-expected (local.get $proc))
-                        (unreachable)))
-              (local.set $f    (ref.cast (ref $Procedure) (local.get $proc)))
-              (local.set $finv (struct.get $Procedure $invoke (local.get $f)))
-
-              ;; 2) Walk vecs list, count vectors, ensure each is a vector and same length
-              (local.set $nvecs (i32.const 0))
-              (local.set $cur   (local.get $vecs))
-              (block $count-done
-                     (loop $count
-                           (if (ref.eq (local.get $cur) (global.get $null))
-                               (then (br $count-done)))
-                           (if (i32.eqz (ref.test (ref $Pair) (local.get $cur)))
-                               (then (call $raise-pair-expected (local.get $cur))
-                                     (unreachable)))
-                           (local.set $pair (ref.cast (ref $Pair) (local.get $cur)))
-                           (local.set $vec (struct.get $Pair $a (local.get $pair)))
-                           (if (i32.eqz (ref.test (ref $Vector) (local.get $vec)))
-                               (then (call $raise-check-vector (local.get $vec))
-                                     (unreachable)))
-                           (local.set $vec (ref.cast (ref $Vector) (local.get $vec)))
-                           (if (i32.eq (local.get $nvecs) (i32.const 0))
-                               (then (local.set $len (array.len (struct.get $Vector $arr (local.get $vec)))))
-                               (else (if (i32.ne (array.len (struct.get $Vector $arr (local.get $vec)))
-                                            (local.get $len))
-                                         (then (call $raise-argument-error (local.get $vec))
-                                               (unreachable)))))
-                           (local.set $nvecs (i32.add (local.get $nvecs) (i32.const 1)))
-                           (local.set $cur (struct.get $Pair $d (local.get $pair)))
-                           (br $count)))
-              ;; Require at least one vector
-              (if (i32.eq (local.get $nvecs) (i32.const 0))
+              ;; Ensure a non-empty list of vectors
+              (if (ref.eq (local.get $vecs) (global.get $null))
                   (then (call $raise-arity-mismatch) (unreachable)))
+              (if (i32.eqz (ref.test (ref $Pair) (local.get $vecs)))
+                  (then (call $raise-pair-expected (local.get $vecs))
+                        (unreachable)))
+              (local.set $pair (ref.cast (ref $Pair) (local.get $vecs)))
+              (local.set $v0   (struct.get $Pair $a (local.get $pair)))
+              (local.set $rest (struct.get $Pair $d (local.get $pair)))
 
-              ;; 3) Allocate arrays and seed vectors
-              (local.set $vectors (array.new $Args (global.get $null) (local.get $nvecs)))
-              (local.set $call    (array.new $Args (global.get $null) (local.get $nvecs)))
-              (local.set $res     (call $make-array (local.get $len) (global.get $false)))
-
-              (local.set $cur (local.get $vecs))
-              (local.set $i   (i32.const 0))
-              (block $seed-done
-                     (loop $seed
-                           (if (i32.ge_u (local.get $i) (local.get $nvecs))
-                               (then (br $seed-done)))
-                           (local.set $pair (ref.cast (ref $Pair) (local.get $cur)))
-                           (array.set $Args (local.get $vectors) (local.get $i)
-                                       (ref.cast (ref $Vector)
-                                                 (struct.get $Pair $a (local.get $pair))))
-                           (local.set $cur (struct.get $Pair $d (local.get $pair)))
-                           (local.set $i (i32.add (local.get $i) (i32.const 1)))
-                           (br $seed)))
-
-              ;; 4) Iterate through indices and build result
-              (local.set $j (i32.const 0))
-              (block $done
-                     (loop $loop
-                           (br_if $done (i32.ge_u (local.get $j) (local.get $len)))
-
-                           ;; Build call arguments for this index
-                           (local.set $i (i32.const 0))
-                           (block $args-done
-                                  (loop $args
-                                        (if (i32.ge_u (local.get $i) (local.get $nvecs))
-                                            (then (br $args-done)))
-                                        (local.set $vec
-                                                   (ref.cast (ref $Vector)
-                                                             (array.get $Args (local.get $vectors) (local.get $i))))
-                                        (local.set $elem
-                                                   (array.get $Array
-                                                             (struct.get $Vector $arr (local.get $vec))
-                                                             (local.get $j)))
-                                        (array.set $Args (local.get $call) (local.get $i) (local.get $elem))
-                                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
-                                        (br $args)))
-
-                           ;; Invoke procedure and store result
-                           (local.set $r
-                                      (call_ref $ProcedureInvoker
-                                                (local.get $f)
-                                                (local.get $call)
-                                                (local.get $finv)))
-                           (array.set $Array (local.get $res) (local.get $j) (local.get $r))
-
-                           (local.set $j (i32.add (local.get $j) (i32.const 1)))
-                           (br $loop)))
-
-              (struct.new $Vector (i32.const 0)
-                          (i32.const 0)
-                          (local.get $res)))
+              ;; Copy first vector and delegate to vector-map!
+              (call $vector-map! (local.get $proc)
+                                 (call $vector-copy (local.get $v0)
+                                                    (global.get $missing)
+                                                    (global.get $missing))
+                                 (local.get $rest)))
 
         (func $vector-map! (type $Prim>=2)
               (param $proc (ref eq))


### PR DESCRIPTION
## Summary
- Reduce duplicated logic between `vector-map` and `vector-map!`
- Implement `vector-map` by copying the first vector and delegating to `vector-map!`

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b7498d008322a5cf2a63d879e056