### PR TITLE
Add point predicate and vector support to JSXGraph example

### DIFF
--- a/test/jsxgraph-example.rkt
+++ b/test/jsxgraph-example.rkt
@@ -200,7 +200,7 @@
 
 (define (point? x)
   (and (external? x)
-       ...???...))
+       (js-instanceof x (dot (js-var "JXG") "Point"))))
 
 (define (point-x p)
   (js-send/flonum* p "X"))
@@ -225,7 +225,7 @@
   (match obj
     [(vector x y) obj]
     [(list   x y) (vector x y)]
-    #;[(? point?)   (vector (point-x obj) (point-y obj))]
+    [(? point?)   (vector (point-x obj) (point-y obj))]
     [_ (error 'as-vector msg obj)]))
 
 (define (vector-plus v w)


### PR DESCRIPTION
## Summary
- Implement `point?` to recognize `JXG.Point` values.
- Extend `as-vector` to handle point arguments by returning their coordinates.


------
https://chatgpt.com/codex/tasks/task_e_68b8d52999b4832286adfccd31d9ca71