### PR TITLE
Add unsafe vector primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -613,6 +613,8 @@
   unsafe-car
   unsafe-cdr
   unsafe-struct-ref
+  unsafe-vector-length
+  unsafe-vector-ref
   unsafe-vector*-length
   unsafe-vector*-set!
   unsafe-struct-set!

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -426,7 +426,7 @@ for-each
  unsafe-flacos unsafe-flatan unsafe-fllog unsafe-flexp unsafe-flsqrt
  unsafe-flmin unsafe-flmax unsafe-flexpt
  unsafe-fx= unsafe-fx< unsafe-car unsafe-cdr
- unsafe-struct-ref unsafe-vector*-length unsafe-vector*-set! unsafe-struct-set!
+ unsafe-struct-ref unsafe-vector-length unsafe-vector-ref unsafe-vector*-length unsafe-vector*-set! unsafe-struct-set!
  
 
  ;; 14.1 Namespaces

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -15657,11 +15657,30 @@
                                                           (local.get $k)))
                                      (i32.const 1))))
 
-         ;; Note the `unsafe-vector*-...` variants do not work on impersonators.
-         ;; (the `unsafe-vector-...` variants do)
-         (func $unsafe-vector*-length (type $Prim1) (param $v (ref eq)) (result (ref eq))
-               (local $vec (ref $Vector))
-               (local.set $vec (ref.cast (ref $Vector) (local.get $v)))
+        (func $unsafe-vector-length (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (local $vec (ref $Vector))
+              (local.set $vec (ref.cast (ref $Vector) (local.get $v)))
+              (ref.i31 (i32.shl
+                        (array.len
+                         (struct.get $Vector $arr (local.get $vec)))
+                        (i32.const 1))))
+
+        (func $unsafe-vector-ref (type $Prim2)
+              (param $v (ref eq))
+              (param $k (ref eq))
+              (result (ref eq))
+              (array.get $Array
+                         (struct.get $Vector $arr
+                                     (ref.cast (ref $Vector) (local.get $v)))
+                         (i32.shr_s (i31.get_s (ref.cast (ref i31)
+                                                         (local.get $k)))
+                                    (i32.const 1))))
+
+        ;; Note the `unsafe-vector*-...` variants do not work on impersonators.
+        ;; (the `unsafe-vector-...` variants do)
+        (func $unsafe-vector*-length (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (local $vec (ref $Vector))
+              (local.set $vec (ref.cast (ref $Vector) (local.get $v)))
                (ref.i31 (i32.shl
                          (array.len
                           (struct.get $Vector $arr (local.get $vec)))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1327,6 +1327,12 @@
               (and (equal? (vector-length '#(1 2 3)) 3)
                    (equal? (vector-length '#()) 0)))
 
+        (list "unsafe-vector-length"
+              (equal? (unsafe-vector-length '#(1 2 3)) 3))
+
+        (list "unsafe-vector-ref"
+              (equal? (unsafe-vector-ref '#(10 20 30) 1) 20))
+
         (list "vector-fill!"
               (let ([v (vector 1 2 3)])
                 (vector-fill! v 9)


### PR DESCRIPTION
## Summary
- support unsafe-vector-length and unsafe-vector-ref in runtime
- expose unsafe vector primitives to compiler and primitive lists
- cover unsafe vector operations with tests

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d7d2cc888322b7dd1a1aecc7739f