### PR TITLE
Add JavaScript Number bindings

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -671,6 +671,60 @@ var imports = {
         'tanh':   ((x)       => Math.tanh(x)),
         'trunc':  ((x)       => Math.trunc(x))
     },
+    'number': {
+        // Machine epsilon constant.
+        'epsilon':           (() => Number.EPSILON),
+        // Largest safe integer.
+        'max-safe-integer':  (() => Number.MAX_SAFE_INTEGER),
+        // Greatest finite number.
+        'max-value':         (() => Number.MAX_VALUE),
+        // Smallest safe integer.
+        'min-safe-integer':  (() => Number.MIN_SAFE_INTEGER),
+        // Smallest positive non-zero number.
+        'min-value':         (() => Number.MIN_VALUE),
+        // IEEE NaN value.
+        'nan':               (() => Number.NaN),
+        // Negative infinity constant.
+        'negative-infinity': (() => Number.NEGATIVE_INFINITY),
+        // Positive infinity constant.
+        'positive-infinity': (() => Number.POSITIVE_INFINITY),
+        // Test whether a value is finite.
+        'is-finite':         (x => Number.isFinite(x) ? 1 : 0),
+        // Test whether a value is an integer.
+        'is-integer':        (x => Number.isInteger(x) ? 1 : 0),
+        // Test whether a value is NaN.
+        'is-nan':            (x => Number.isNaN(x) ? 1 : 0),
+        // Test whether a value is a safe integer.
+        'is-safe-integer':   (x => Number.isSafeInteger(x) ? 1 : 0),
+        // Parse string into floating-point number.
+        'parse-float':       (s => Number.parseFloat(from_fasl(s))),
+        // Parse string into integer.
+        'parse-int':         (s => Number.parseInt(from_fasl(s))),
+        // Convert number to exponential notation.
+        'to-exponential':    ((x, fd) => {
+                                 const d = from_fasl(fd);
+                                 return d === undefined ? x.toExponential() : x.toExponential(d);
+                               }),
+        // Format number with fixed-point notation.
+        'to-fixed':          ((x, digits) => {
+                                 const d = from_fasl(digits);
+                                 return d === undefined ? x.toFixed() : x.toFixed(d);
+                               }),
+        // Format number using locale-specific rules.
+        'to-locale-string':  ((x, locales, options) => x.toLocaleString(from_fasl(locales), from_fasl(options))),
+        // Format number with specified precision.
+        'to-precision':      ((x, precision) => {
+                                 const p = from_fasl(precision);
+                                 return p === undefined ? x.toPrecision() : x.toPrecision(p);
+                               }),
+        // Convert number to string with optional radix.
+        'to-string':         ((x, radix) => {
+                                 const r = from_fasl(radix);
+                                 return r === undefined ? x.toString() : x.toString(r);
+                               }),
+        // Extract primitive numeric value.
+        'value-of':          (x => x.valueOf())
+    },
     'array': {
         'length':            (arr => arr.length),
         'set-length!':       ((arr, len) => { arr.length = len; }),

--- a/standard.ffi
+++ b/standard.ffi
@@ -286,6 +286,137 @@
   (-> () (extern)))
 
 ;;;
+;;; Number
+;;;
+
+;; See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+;; Smallest increment between 1 and the next representable f64.
+(define-foreign js-number-epsilon
+  #:module "number"
+  #:name   "epsilon"
+  (-> () (f64)))
+
+;; Largest f64 value where integers are represented exactly.
+(define-foreign js-number-max-safe-integer
+  #:module "number"
+  #:name   "max-safe-integer"
+  (-> () (f64)))
+
+;; Greatest finite f64.
+(define-foreign js-number-max-value
+  #:module "number"
+  #:name   "max-value"
+  (-> () (f64)))
+
+;; Smallest f64 value where integers are represented exactly.
+(define-foreign js-number-min-safe-integer
+  #:module "number"
+  #:name   "min-safe-integer"
+  (-> () (f64)))
+
+;; Smallest positive non-zero f64.
+(define-foreign js-number-min-value
+  #:module "number"
+  #:name   "min-value"
+  (-> () (f64)))
+
+;; IEEE NaN value.
+(define-foreign js-number-nan
+  #:module "number"
+  #:name   "nan"
+  (-> () (f64)))
+
+;; Negative infinity constant.
+(define-foreign js-number-negative-infinity
+  #:module "number"
+  #:name   "negative-infinity"
+  (-> () (f64)))
+
+;; Positive infinity constant.
+(define-foreign js-number-positive-infinity
+  #:module "number"
+  #:name   "positive-infinity"
+  (-> () (f64)))
+
+;; Test whether a value is finite.
+(define-foreign js-number-finite?
+  #:module "number"
+  #:name   "is-finite"
+  (-> (f64) (i32)))
+
+;; Test whether a value is an integer.
+(define-foreign js-number-integer?
+  #:module "number"
+  #:name   "is-integer"
+  (-> (f64) (i32)))
+
+;; Test whether a value is NaN.
+(define-foreign js-number-nan?
+  #:module "number"
+  #:name   "is-nan"
+  (-> (f64) (i32)))
+
+;; Test whether a value is a safe integer.
+(define-foreign js-number-safe-integer?
+  #:module "number"
+  #:name   "is-safe-integer"
+  (-> (f64) (i32)))
+
+;; Parse a string into an f64.
+(define-foreign js-number-parse-float
+  #:module "number"
+  #:name   "parse-float"
+  (-> (string) (f64)))
+
+;; Parse a string into a base-10 integer.
+(define-foreign js-number-parse-int
+  #:module "number"
+  #:name   "parse-int"
+  (-> (string) (f64)))
+
+;; Convert value to exponential notation.
+(define-foreign js-number-to-exponential
+  #:module "number"
+  #:name   "to-exponential"
+  ;; Pass `(void)` for missing fraction-digits.
+  (-> (f64 value) (string)))
+
+;; Format value with fixed-point notation.
+(define-foreign js-number-to-fixed
+  #:module "number"
+  #:name   "to-fixed"
+  ;; Pass `(void)` for missing digits.
+  (-> (f64 value) (string)))
+
+;; Format value using locale-specific rules.
+(define-foreign js-number-to-locale-string
+  #:module "number"
+  #:name   "to-locale-string"
+  ;; Pass `(void)` for missing locales and options.
+  (-> (f64 value value) (string)))
+
+;; Format value with specified precision.
+(define-foreign js-number-to-precision
+  #:module "number"
+  #:name   "to-precision"
+  ;; Pass `(void)` for missing precision.
+  (-> (f64 value) (string)))
+
+;; Convert value to string, optionally using a radix.
+(define-foreign js-number-to-string
+  #:module "number"
+  #:name   "to-string"
+  ;; Pass `(void)` for missing radix.
+  (-> (f64 value) (string)))
+
+;; Extract the primitive numeric value.
+(define-foreign js-number-value-of
+  #:module "number"
+  #:name   "value-of"
+  (-> (f64) (f64)))
+
+;;;
 ;;; Text processing
 ;;;
 


### PR DESCRIPTION
## Summary
- add foreign bindings for JavaScript `Number` properties and methods
- expose `Number` helpers in assembler for runtime support
- document each binding with a one-line description

## Testing
- `raco test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b95e2ada7c832280946970ac561dc4