### PR TITLE
Use boolean return for Number predicates

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -703,13 +703,13 @@ var imports = {
         // Positive infinity constant.
         'positive-infinity': (() => Number.POSITIVE_INFINITY),
         // Test whether a value is finite.
-        'is-finite':         (x => Number.isFinite(x) ? 1 : 0),
+        'is-finite':         (x => boolean_to_i32(Number.isFinite(x))),
         // Test whether a value is an integer.
-        'is-integer':        (x => Number.isInteger(x) ? 1 : 0),
+        'is-integer':        (x => boolean_to_i32(Number.isInteger(x))),
         // Test whether a value is NaN.
-        'is-nan':            (x => Number.isNaN(x) ? 1 : 0),
+        'is-nan':            (x => boolean_to_i32(Number.isNaN(x))),
         // Test whether a value is a safe integer.
-        'is-safe-integer':   (x => Number.isSafeInteger(x) ? 1 : 0),
+        'is-safe-integer':   (x => boolean_to_i32(Number.isSafeInteger(x))),
         // Parse string into floating-point number.
         'parse-float':       (s => Number.parseFloat(from_fasl(s))),
         // Parse string into integer.

--- a/standard.ffi
+++ b/standard.ffi
@@ -343,25 +343,25 @@
 (define-foreign js-number-finite?
   #:module "number"
   #:name   "is-finite"
-  (-> (f64) (i32)))
+  (-> (f64) (boolean)))
 
 ;; Test whether a value is an integer.
 (define-foreign js-number-integer?
   #:module "number"
   #:name   "is-integer"
-  (-> (f64) (i32)))
+  (-> (f64) (boolean)))
 
 ;; Test whether a value is NaN.
 (define-foreign js-number-nan?
   #:module "number"
   #:name   "is-nan"
-  (-> (f64) (i32)))
+  (-> (f64) (boolean)))
 
 ;; Test whether a value is a safe integer.
 (define-foreign js-number-safe-integer?
   #:module "number"
   #:name   "is-safe-integer"
-  (-> (f64) (i32)))
+  (-> (f64) (boolean)))
 
 ;; Parse a string into an f64.
 (define-foreign js-number-parse-float


### PR DESCRIPTION
## Summary
- Update Number predicate bindings to return boolean values instead of i32 flags
- Ensure JS Number predicate implementations emit 0/1 results

## Testing
- `raco test test/test-ffi.rkt` *(fails: command not found: raco)*

------
https://chatgpt.com/codex/tasks/task_e_68b98b93f5f48322978a0fb0e1fd035b