### PR TITLE
Write FASL results into shared memory

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -163,7 +163,9 @@ function fasl_to_js_value(arr, i = 0) {
 }
 
 function to_fasl(v) {
-  return js_value_to_fasl(v)
+  const fasl = js_value_to_fasl(v);
+  new Uint8Array(memory.buffer).set(fasl, 0);
+  return 0
 }
 
 function js_value_to_fasl(v) {


### PR DESCRIPTION
## Summary
- Return FASL results to Wasm by copying bytes into linear memory at offset 0 and reporting that offset.

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b9931943e08322b53856ad3fd14b10