### PR TITLE
Encode js-ref results as FASL

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -547,6 +547,7 @@ var imports = {
       'encode-uri':                ((s) => to_string( encodeURI(from_fasl(s)))),
       'encode-uri-component':      ((s) => to_string( encodeURIComponent(from_fasl(s)))),
       'var':                       ((name) => globalThis[from_fasl(name)]),
+      'ref/value':                 ((obj, key) => to_fasl(obj[from_fasl(key)])),
       'ref':                       ((obj, key) => obj[from_fasl(key)]),
       'set!':                      ((obj, key, val) => { obj[from_fasl(key)] = from_fasl(val); }),
       'index':                     ((obj, prop) => obj[from_fasl(prop)]),

--- a/standard.ffi
+++ b/standard.ffi
@@ -104,7 +104,7 @@
 
 (define-foreign js-ref
   #:module "standard"
-  #:name   "ref"
+  #:name   "ref/value"
   (-> (extern string/symbol) (value)))
 
 (define-foreign js-set!

--- a/test/test-ffi.rkt
+++ b/test/test-ffi.rkt
@@ -54,12 +54,11 @@
               (let ([s "a b+c"])
                 (equal? (js-decode-uri-component (js-encode-uri-component s)) s)))        
         (list "js-ref/js-set!/js-assign"
-              (let ([and list] [equal? list])
               (let ([obj (js-object (list))])
                 (js-set! obj "a" 1)
-                (and (equal? (js-ref obj "a") 1)    ; js-ref returns an external?
+                (and (equal? (js-ref obj "a") 1)
                      (equal? (js-assign "b" 2) (void))
-                     (equal? (js-ref (js-global-this) "b") 2)))))))
+                     (equal? (js-ref (js-global-this) "b") 2))))))
 
  #;(list "Basic operations"
        (list


### PR DESCRIPTION
## Summary
- Encode js-ref property lookups with FASL to return proper Racket values
- Use dedicated host binding for js-ref returning values
- Verify js-ref, js-set!, and js-assign via ffi test

## Testing
- `racket test/test-ffi.rkt` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a618cd908322b1e3ce78639b9ac7