### PR TITLE
Add external-string->string primitive

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -525,6 +525,11 @@ var imports = {
         (typeof obj === 'number'
          ? obj
          : (obj instanceof Number ? obj.valueOf() : NaN))),
+      'external_string_to_string': (obj =>
+        (typeof obj === 'string'
+         ? to_string(obj)
+         : (obj instanceof String ? to_string(obj.valueOf())
+                                   : to_string(String(obj))))),
       'char_upcase': ((cp) => {
         const s = String.fromCodePoint(cp).toUpperCase();
         const arr = Array.from(s);

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -632,6 +632,7 @@
   ; shrink-vector
 
   external-number->flonum
+  external-string->string
   external?
   )
 

--- a/priminfo.rkt
+++ b/priminfo.rkt
@@ -63,6 +63,7 @@
     js-log
     procedure->external
     external-number->flonum
+    external-string->string
     ))
 
 

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -444,6 +444,7 @@ for-each
  fasl->s-exp
  procedure->external
  external-number->flonum
+ external-string->string
  js-log
  external?
 
@@ -460,6 +461,10 @@ for-each
 (define (external-number->flonum x)
   (cond [(number? x) (exact->inexact x)]
         [else (raise-argument-error 'external-number->flonum "number?" x)]))
+
+(define (external-string->string x)
+  (cond [(string? x) x]
+        [else (raise-argument-error 'external-string->string "string?" x)]))
 
 
 ;; Changed in version 8.15.0.7: Added string-find.


### PR DESCRIPTION
## Summary
- handle external host strings with new `external-string->string` primitive
- expose primitive to compiler, runtime, and Racket stubs

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found: raco)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0d39efd8832292992de8b3266d37