### PR TITLE
Add performance.now bindings

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -1243,6 +1243,10 @@ var imports = {
         'queue-microtask':     (cb => window.queueMicrotask(cb)),
         'report-error':        (err => window.reportError(err))
     } : new Proxy({}, { get() { throw new Error('DOM not available in this environment'); } }),
+    // Performance
+    'performance': hasDOM ? {
+        'now':                 (() => performance.now())
+    } : new Proxy({}, { get() { throw new Error('DOM not available in this environment'); } }),
     // Document
     'document': hasDOM ? {
         'document':                 (()                               => document),

--- a/dom.ffi
+++ b/dom.ffi
@@ -469,6 +469,16 @@
   #:name   "report-error"
   (-> (value) ()))
 
+;;; Performance
+;;;
+; The various functions in this section are documented here:
+;   https://developer.mozilla.org/en-US/docs/Web/API/Performance
+
+(define-foreign js-performance-now
+  #:module "performance"
+  #:name   "now"
+  (-> () (f64)))
+
 ;;; Document
 ;;;
 


### PR DESCRIPTION
## Summary
- add Performance section to DOM FFI with `js-performance-now`
- wire `performance.now` through assembler for runtime access

## Testing
- `raco test dom.ffi assembler.rkt` *(fails: command not found: raco)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bab9f4da8c8322915118273a9859be