### PR TITLE
Add point predicate to JSXGraph FFI

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -1729,6 +1729,7 @@ var imports = {
     },
     // JSXGraph Point
     'jsx-point': hasDOM ? {
+        'is-point':                    (v => boolean_to_i32(JXG.isPoint(v))),
         'attractor-distance':          (pt => pt.attractorDistance),
         'set-attractor-distance!':     ((pt, d) => { pt.attractorDistance = d; }),
         'attractors':                  (pt => pt.attractors),
@@ -1774,6 +1775,7 @@ var imports = {
         'update-renderer!':            (pt => { pt.updateRenderer(); }),
         'update-transform!':           ((pt, flag) => pt.updateTransform(!!flag))
     } : {
+        'is-point'()                    { throw new Error('DOM not available in this environment'); },
         'attractor-distance'()          { throw new Error('DOM not available in this environment'); },
         'set-attractor-distance!'()     { throw new Error('DOM not available in this environment'); },
         'attractors'()                  { throw new Error('DOM not available in this environment'); },

--- a/jsxgraph.ffi
+++ b/jsxgraph.ffi
@@ -4,6 +4,14 @@
 
 ;;; Point
 
+;; Predicates
+;; Test whether value is a point
+; (jsx-point? v:Extern) -> Boolean
+(define-foreign jsx-point?
+  #:module "jsx-point"
+  #:name   "is-point"
+  (-> (extern) (i32)))
+
 ;; Properties
 ;; Distance at which point is captured by attractors
 ; (jsx-point-attractor-distance pt:Extern) -> Flonum


### PR DESCRIPTION
## Summary
- add `jsx-point?` to query whether an external value is a JSXGraph point
- expose corresponding `is-point` helper in assembler mapping

## Testing
- `raco test test/test-ffi.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68babfaf1bc88322b5b0b7f42b77d23a