### PR TITLE
Add pico.css stylesheet to Ceva's theorem example

### DIFF
--- a/test/cevas-theorem.rkt
+++ b/test/cevas-theorem.rkt
@@ -71,6 +71,13 @@
                    "https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css")
 (js-append-child! head link)
 
+;; Use the pico.css stylesheet
+(define pico-link (js-create-element "link"))
+(js-set-attribute! pico-link "rel" "stylesheet")
+(js-set-attribute! pico-link "href"
+                   "https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css")
+(js-append-child! head pico-link)
+
 ;;;
 ;;; Syntax
 ;;;


### PR DESCRIPTION
## Summary
- add pico.css link to Ceva's theorem example for improved styling

## Testing
- `raco test test/cevas-theorem.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6b5278e48322a9c2a045870906a3