### PR TITLE
Add flatten primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -412,6 +412,7 @@
   list? length list-ref list-tail
   first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth last last-pair
   append ; variadic list primitive
+  flatten
   reverse memq
   alt-reverse ; used in expansion of for/list
   map andmap ormap for-each

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -333,6 +333,7 @@ bytes->string/utf-8
  last
  last-pair
  append
+ flatten
  reverse
 
  map

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -10040,6 +10040,37 @@
                              (else (call $raise-pair-expected (local.get $xs))
                                    (unreachable))))))
 
+         (func $flatten (type $Prim1) (param $v (ref eq)) (result (ref eq))
+               (local $stack (ref eq))
+               (local $node  (ref $Pair))
+               (local $cur   (ref eq))
+               (local $p     (ref $Pair))
+               (local $acc   (ref eq))
+
+               ;; Initialize stack with initial value and empty accumulator
+               (local.set $stack (call $cons (local.get $v) (global.get $null)))
+               (local.set $acc   (global.get $null))
+
+               (block $done
+                      (loop $loop
+                            (br_if $done (ref.eq (local.get $stack) (global.get $null)))
+                            (local.set $node (ref.cast (ref $Pair) (local.get $stack)))
+                            (local.set $cur  (struct.get $Pair $a (local.get $node)))
+                            (local.set $stack (struct.get $Pair $d (local.get $node)))
+                            (if (ref.eq (local.get $cur) (global.get $null))
+                                (then (nop))
+                                (else
+                                 (if (ref.test (ref $Pair) (local.get $cur))
+                                     (then
+                                      (local.set $p (ref.cast (ref $Pair) (local.get $cur)))
+                                      ;; Push cdr then car to visit car first
+                                      (local.set $stack (call $cons (struct.get $Pair $d (local.get $p)) (local.get $stack)))
+                                      (local.set $stack (call $cons (struct.get $Pair $a (local.get $p)) (local.get $stack))))
+                                     (else
+                                      (local.set $acc (call $cons (local.get $cur) (local.get $acc))))))
+                            (br $loop)))
+               (call $reverse (local.get $acc)))
+
          (func $reverse (type $Prim1) (param $xs (ref eq)) (result (ref eq))
                (local $acc (ref eq))
                (local.set $acc (global.get $null))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1149,6 +1149,11 @@
                    (equal? (reverse '(a (b c) d (e (f)))) '((e (f)) d (b c) a))
                    (equal? (procedure-arity reverse)      1)))
 
+        (list "flatten"
+              (and (equal? (flatten '((a) b (c (d) . e) ())) '(a b c d e))
+                   (equal? (flatten 'a)                     '(a))
+                   (equal? (procedure-arity flatten)        1)))
+
         (list "list-ref"
               (and (equal? (list-ref '(a b c d) 2)    'c)
                    (equal? (list-ref '(a b c . d) 2)  'c)


### PR DESCRIPTION
## Summary
- implement `flatten` primitive and runtime support
- expose `flatten` via compiler and Racket bindings

## Testing
- `racket test/test-basics.rkt` *(command failed: command not found)*
- `apt-get update` *(command failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbd64e4b08322ac6651d4b7288231