### PR TITLE
Add xor primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -427,7 +427,7 @@
   void
 
   ;; BOOLEANS
-  boolean? not immutable?
+  boolean? not xor immutable?
 
   ;; CHARACTERS
   char?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -46,6 +46,7 @@
  ;; 4.2 Booleans
  not
  boolean?
+ xor
  immutable?
 
  ;; 4.3 Numbers

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2504,7 +2504,7 @@
          ;; [ ] nand
          ;; [ ] nor
          ;; [ ] implies
-         ;; [ ] xor
+        ;; [x] xor
 
          ;;; Mutability Predicates
          ;; [ ] mutable-string?
@@ -2540,11 +2540,23 @@
                              (else (global.get $false))))
                    (else (global.get $false))))
 
-         (func $not (type $Prim1) (param $v (ref eq)) (result (ref eq))
-               (if (result (ref eq))
-                   (ref.eq (local.get $v) (global.get $false))
-                   (then (global.get $true))
+        (func $not (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.eq (local.get $v) (global.get $false))
+                  (then (global.get $true))
                    (else (global.get $false))))
+
+        (func $xor (type $Prim2) (param $b1 (ref eq)) (param $b2 (ref eq)) (result (ref eq))
+               (if (result (ref eq))
+                   (ref.eq (local.get $b1) (global.get $false))
+                   (then (if (result (ref eq))
+                             (ref.eq (local.get $b2) (global.get $false))
+                             (then (global.get $false))
+                             (else (local.get $b2))))
+                   (else (if (result (ref eq))
+                             (ref.eq (local.get $b2) (global.get $false))
+                             (then (local.get $b1))
+                             (else (global.get $false))))))
 
          (func $immutable? (type $Prim1)
                (param $v (ref eq))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -152,6 +152,12 @@
                    (equal? (boolean? 0)   #f)
                    (equal? (boolean? '()) #f)
                    (equal? (procedure-arity boolean?) 1)))
+        (list "xor"
+              (and (equal? (xor 11 #f) 11)
+                   (equal? (xor #f 22) 22)
+                   (equal? (xor 11 22) #f)
+                   (equal? (xor #f #f) #f)
+                   (equal? (procedure-arity xor) 2)))
         (list "immutable?"
               (and  (equal? (immutable? "a") #t)
                     (equal? (immutable? (string-copy "a")) #f)


### PR DESCRIPTION
## Summary
- implement `xor` primitive in the wasm runtime
- register and export `xor` so it can be used from compiled code
- cover `xor` with basic evaluation

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd40d5436883228ce18c81a6627709