### PR TITLE
Implement false? primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -427,7 +427,7 @@
   void
 
   ;; BOOLEANS
-  boolean? boolean=? not xor immutable?
+  boolean? boolean=? false? not xor immutable?
 
   ;; CHARACTERS
   char?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -47,6 +47,7 @@
  not
  boolean?
  boolean=?
+ false?
  xor
  immutable?
 

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2498,9 +2498,9 @@
          ;;; Boolean Aliases
          ;; [ ] true
          ;; [ ] false
-         ;; [ ] symbol=?
-         ;; [ ] boolean=?
-         ;; [ ] false?
+        ;; [ ] symbol=?
+        ;; [x] boolean=?
+        ;; [x] false?
          ;; [ ] nand
          ;; [ ] nor
          ;; [ ] implies
@@ -2556,10 +2556,16 @@
                    (then (global.get $true))
                    (else (global.get $false))))
 
-         (func $not (type $Prim1) (param $v (ref eq)) (result (ref eq))
-               (if (result (ref eq))
-                   (ref.eq (local.get $v) (global.get $false))
-                   (then (global.get $true))
+        (func $false? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.eq (local.get $v) (global.get $false))
+                  (then (global.get $true))
+                  (else (global.get $false))))
+
+        (func $not (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.eq (local.get $v) (global.get $false))
+                  (then (global.get $true))
                    (else (global.get $false))))
 
         (func $xor (type $Prim2) (param $b1 (ref eq)) (param $b2 (ref eq)) (result (ref eq))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -157,6 +157,11 @@
                    (equal? (boolean=? #t #f) #f)
                    (equal? (boolean=? #f #f) #t)
                    (equal? (procedure-arity boolean=?) 2)))
+        (list "false?"
+              (and (equal? (false? #f) #t)
+                   (equal? (false? #t) #f)
+                   (equal? (false? 0)  #f)
+                   (equal? (procedure-arity false?) 1)))
         (list "xor"
               (and (equal? (xor 11 #f) 11)
                    (equal? (xor #f 22) 22)


### PR DESCRIPTION
## Summary
- add runtime support for `false?`
- expose `false?` to the compiler and primitives
- cover `false?` with basic boolean tests

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*
- `raco test test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd445cf74083228ca8ce01da07640e