### PR TITLE
Add mutability predicate primitives

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -428,6 +428,11 @@
 
   ;; BOOLEANS
   boolean? boolean=? false? not xor immutable?
+  mutable-string? immutable-string?
+  mutable-bytes? immutable-bytes?
+  mutable-vector? immutable-vector?
+  mutable-box? immutable-box?
+  mutable-hash? immutable-hash?
 
   ;; CHARACTERS
   char?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -19,6 +19,7 @@
          racket/string
          racket/symbol
          racket/vector
+         racket/mutability
          racket/unsafe/ops
          (prefix-in imm: "immediates.rkt"))
 
@@ -50,6 +51,16 @@
  false?
  xor
  immutable?
+ mutable-string?
+ immutable-string?
+ mutable-bytes?
+ immutable-bytes?
+ mutable-vector?
+ immutable-vector?
+ mutable-box?
+ immutable-box?
+ mutable-hash?
+ immutable-hash?
 
  ;; 4.3 Numbers
 

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2507,16 +2507,118 @@
         ;; [x] xor
 
          ;;; Mutability Predicates
-         ;; [ ] mutable-string?
-         ;; [ ] immutable-string?
-         ;; [ ] mutable-bytes?
-         ;; [ ] immutable-bytes?
-         ;; [ ] mutable-vector?
-         ;; [ ] immutable-vector?
-         ;; [ ] mutable-box?
-         ;; [ ] immutable-box?
-         ;; [ ] mutable-hash?
-         ;; [ ] immutable-hash?
+        ;; [x] mutable-string?
+        ;; [x] immutable-string?
+        ;; [x] mutable-bytes?
+        ;; [x] immutable-bytes?
+        ;; [x] mutable-vector?
+        ;; [x] immutable-vector?
+        ;; [x] mutable-box?
+        ;; [x] immutable-box?
+        ;; [x] mutable-hash?
+        ;; [x] immutable-hash?
+
+        (func $mutable-string? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $String) (local.get $v))
+                  (then (if (result (ref eq))
+                             (i32.eq (struct.get $String $immutable
+                                                 (ref.cast (ref $String) (local.get $v)))
+                                      (i32.const 0))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
+
+        (func $immutable-string? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $String) (local.get $v))
+                  (then (if (result (ref eq))
+                             (i32.eq (struct.get $String $immutable
+                                                 (ref.cast (ref $String) (local.get $v)))
+                                      (i32.const 1))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
+
+        (func $mutable-bytes? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Bytes) (local.get $v))
+                  (then (if (result (ref eq))
+                             (i32.eq (struct.get $Bytes $immutable
+                                                 (ref.cast (ref $Bytes) (local.get $v)))
+                                      (i32.const 0))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
+
+        (func $immutable-bytes? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Bytes) (local.get $v))
+                  (then (if (result (ref eq))
+                             (i32.eq (struct.get $Bytes $immutable
+                                                 (ref.cast (ref $Bytes) (local.get $v)))
+                                      (i32.const 1))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
+
+        (func $mutable-vector? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Vector) (local.get $v))
+                  (then (if (result (ref eq))
+                             (i32.eq (struct.get $Vector $immutable
+                                                 (ref.cast (ref $Vector) (local.get $v)))
+                                      (i32.const 0))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
+
+        (func $immutable-vector? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Vector) (local.get $v))
+                  (then (if (result (ref eq))
+                             (i32.eq (struct.get $Vector $immutable
+                                                 (ref.cast (ref $Vector) (local.get $v)))
+                                      (i32.const 1))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
+
+        (func $mutable-box? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Box) (local.get $v))
+                  (then (global.get $true))
+                  (else (global.get $false))))
+
+        ;; WebRacket currently only supports mutable boxes.
+        ;; Racket has immutable boxes (#&1), but those are not yet implemented.
+        (func $immutable-box? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Box) (local.get $v))
+                  (then (global.get $false))
+                  (else (global.get $false))))
+
+        (func $mutable-hash? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Hash) (local.get $v))
+                  (then (if (result (ref eq))
+                             (ref.eq (struct.get $Hash $mutable?
+                                                 (ref.cast (ref $Hash) (local.get $v)))
+                                     (global.get $true))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
+
+        (func $immutable-hash? (type $Prim1) (param $v (ref eq)) (result (ref eq))
+              (if (result (ref eq))
+                  (ref.test (ref $Hash) (local.get $v))
+                  (then (if (result (ref eq))
+                             (ref.eq (struct.get $Hash $mutable?
+                                                 (ref.cast (ref $Hash) (local.get $v)))
+                                     (global.get $false))
+                             (then (global.get $true))
+                             (else (global.get $false))))
+                  (else (global.get $false))))
          
          ; todo: Benchmark the two implementations of $boolean? below
 

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -176,7 +176,27 @@
                     (equal? (immutable? (bytes 1 2)) #f)
                     (equal? (immutable? (make-bytes 2 0)) #f)
                     (equal? (immutable? (make-hasheq)) #f)
-                    (equal? (immutable? (box 5)) #f)))))
+                    (equal? (immutable? (box 5)) #f))))
+        (list "Mutability Predicates"
+              (and (equal? (immutable-string? "hi") #t)
+                   (equal? (mutable-string? (string-copy "hi")) #t)
+                   (equal? (mutable-string? "hi") #f)
+                   (equal? (immutable-string? (string-copy "hi")) #f)
+                   (equal? (immutable-bytes? #"ab") #t)
+                   (equal? (mutable-bytes? (bytes 1 2)) #t)
+                   (equal? (mutable-bytes? #"ab") #f)
+                   (equal? (immutable-bytes? (bytes 1 2)) #f)
+                   (equal? (immutable-vector? #(1 2)) #t)
+                   (equal? (mutable-vector? (vector 1 2)) #t)
+                   (equal? (mutable-vector? #(1 2)) #f)
+                   (equal? (immutable-vector? (vector 1 2)) #f)
+                   (equal? (mutable-box? (box 1)) #t)
+                   (equal? (immutable-box? (box 1)) #f)
+                   (equal? (mutable-box? 1) #f)
+                   (equal? (immutable-box? 1) #f)
+                   (equal? (mutable-hash? (make-empty-hasheq)) #t)
+                   (equal? (immutable-hash? (make-empty-hasheq)) #f)))
+        )
  
  (list "4.3 Numbers"
        (list "4.3.1 Number Types"


### PR DESCRIPTION
## Summary
- implement mutable/immutable checks for strings, bytes, vectors, hashes, and boxes
- expose mutability predicates and require `racket/mutability`
- expand test suite with mutability predicate coverage

## Testing
- `raco test test/test-basics.rkt` *(fails: raco not installed)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4607b6088322bba2ac1ed4507e23