### PR TITLE
Implement system-big-endian? primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -493,6 +493,7 @@
   bitwise-first-bit-set  ; note : added in 8.16
   integer-length
   random
+  system-big-endian?
 
   fixnum? fxzero?
   fx+ fx- fx*

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -159,6 +159,7 @@
  degrees->radians
  radians->degrees
  order-of-magnitude
+ system-big-endian?
 
  ;; 4.3.3 Flonums (racket/flonum)
  ;; 4.3.3.1 Flonum Arithmetic

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -4966,6 +4966,11 @@
                              (return (ref.i31 (i32.shl (local.get $r) (i32.const 1))))))))
               (unreachable))
 
+         (func $system-big-endian? (type $Prim0) (result (ref eq))
+               ;; WebAssembly's linear memory is defined as little-endian,
+               ;; so WebRacket always reports a little-endian system.
+               (global.get $false))
+
          ;;;
          ;;;  4.3.4 Fixnums
          ;;;

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -532,6 +532,12 @@
                      (let ([v (random -5 5)])
                        (and (exact-integer? v) (<= -5 v) (< v 5))))))
 
+       (list "4.3.2.8 Byte String Conversions"
+             (list
+              (list "system-big-endian?"
+                    (and (equal? (system-big-endian?) #f)
+                         (equal? (procedure-arity system-big-endian?) 0)))))
+
        (list "4.3.2.10 Extra Constants and Functions"
       (list
        (list "degrees->radians"


### PR DESCRIPTION
## Summary
- add `system-big-endian?` primitive to runtime and compiler
- expose `system-big-endian?` in Racket primitives
- test that `system-big-endian?` reports little-endian system

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd44711a08322b663b177dfba73e3