### PR TITLE
Add type checks for real->floating-point-bytes

### DIFF
--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -536,14 +536,23 @@
 
        (list "4.3.2.9 Byte String Conversions"
              (list
-              (list "real->floating-point-bytes"
-                    (and (bytes=? (real->floating-point-bytes 1.0 8 #t)
-                                    #"\x3f\xf0\x00\x00\x00\x00\x00\x00")
-                         (bytes=? (real->floating-point-bytes 1.0 8 #f)
-                                    #"\x00\x00\x00\x00\x00\x00\xf0\x3f")))))
+             (list "real->floating-point-bytes"
+                   (and (bytes=? (real->floating-point-bytes 1.0 8 #t)
+                                   #"\x3f\xf0\x00\x00\x00\x00\x00\x00")
+                        (bytes=? (real->floating-point-bytes 1.0 8 #f)
+                                   #"\x00\x00\x00\x00\x00\x00\xf0\x3f")))
+             (list "real->floating-point-bytes default"
+                   (bytes=? (real->floating-point-bytes 1.0 8)
+                            #"\x00\x00\x00\x00\x00\x00\xf0\x3f"))
+             (list "real->floating-point-bytes start"
+                   (let* ([dest (make-bytes 10)]
+                          [res  (real->floating-point-bytes 1.0 8 #f dest 2)])
+                     (and (eq? res dest)
+                          (bytes=? dest
+                                   #"\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f"))))
               (list "system-big-endian?"
                     (and (equal? (system-big-endian?) #f)
-                         (equal? (procedure-arity system-big-endian?) 0)))))
+                         (equal? (procedure-arity system-big-endian?) 0))))
 
        (list "4.3.2.10 Extra Constants and Functions"
              (list


### PR DESCRIPTION
## Summary
- validate inputs for `real->floating-point-bytes` and support mutable destination byte strings
- allow non-zero start offsets when writing floating-point bytes
- derive default endianness from `system-big-endian?`

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found: raco)*
- `apt-get update` *(403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bdde69f80c8322b1a13a233ad346c8