### PR TITLE
Add arithmetic-shift primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -491,6 +491,7 @@
 
   bitwise-ior bitwise-and bitwise-xor bitwise-not bitwise-bit-set?
   bitwise-first-bit-set  ; note : added in 8.16
+  arithmetic-shift
   integer-length
   random
 

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -142,13 +142,14 @@
  ;; 4.3.2.5 Complex Numbers
  ;; 4.3.2.6 Bitwise Operations
  bitwise-ior
- bitwise-and
- bitwise-xor
- bitwise-not
- bitwise-bit-set?
- bitwise-first-bit-set  ; added in version 8.16
- integer-length
- random
+  bitwise-and
+  bitwise-xor
+  bitwise-not
+  bitwise-bit-set?
+  bitwise-first-bit-set  ; added in version 8.16
+  arithmetic-shift
+  integer-length
+  random
  ;; 4.3.2.7 Random Numbers
  ;; 4.3.2.8 Other Randomness Utilities (racket/random)
  ;; 4.3.2.9 Number–String Conversions

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -4840,6 +4840,52 @@
                                          (i32.const 1))))))
 
 
+        ;; NOTE: Only supports fixnum arguments; bignum shifts are not implemented.
+        (func $arithmetic-shift (type $Prim2)
+              (param $n (ref eq))
+              (param $m (ref eq))
+              (result   (ref eq))
+
+              (local $n/fx i32)   ; raw bits of n
+              (local $m/fx i32)   ; raw bits of m
+              (local $n/i  i32)   ; unboxed signed n
+              (local $m/i  i32)   ; unboxed signed m
+
+              ;; --- Validate inputs ---
+              (if (ref.eq (call $exact-integer? (local.get $n)) (global.get $false))
+                  (then
+                   (if (ref.test (ref $Flonum) (local.get $n))
+                       (then (nop))
+                       (else (call $raise-expected-number (local.get $n)) (unreachable)))))
+              (if (ref.eq (call $exact-integer? (local.get $m)) (global.get $false))
+                  (then
+                   (if (ref.test (ref $Flonum) (local.get $m))
+                       (then (nop))
+                       (else (call $raise-expected-number (local.get $m)) (unreachable)))))
+
+              ;; --- Convert inputs ---
+              (if (ref.test (ref $Flonum) (local.get $n))
+                  (then (local.set $n (call $fl->exact-integer (local.get $n)))))
+              (if (ref.test (ref $Flonum) (local.get $m))
+                  (then (local.set $m (call $fl->exact-integer (local.get $m)))))
+
+              ;; --- Extract values ---
+              (local.set $n/fx (i31.get_u (ref.cast (ref i31) (local.get $n))))
+              (local.set $m/fx (i31.get_u (ref.cast (ref i31) (local.get $m))))
+              (local.set $n/i  (i32.shr_s (local.get $n/fx) (i32.const 1)))
+              (local.set $m/i  (i32.shr_s (local.get $m/fx) (i32.const 1)))
+
+              ;; --- Compute ---
+              (if (result (ref eq)) (i32.lt_s (local.get $m/i) (i32.const 0))
+                  (then (ref.i31 (i32.shl (i32.shr_s (local.get $n/i)
+                                             (i32.sub (i32.const 0)
+                                                      (local.get $m/i)))
+                                           (i32.const 1))))
+                  (else (ref.i31 (i32.shl (i32.shl (local.get $n/i)
+                                                  (local.get $m/i))
+                                           (i32.const 1)))))
+
+
         (func $integer-length (type $Prim1)
               (param $n (ref eq))
               (result (ref eq))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -510,6 +510,11 @@
               (list "bitwise-first-bit-set"  ; added in Racket 8.16
                     (and (equal? (bitwise-first-bit-set 128) 7)
                          (equal? (bitwise-first-bit-set -8) 3)))
+              (list "arithmetic-shift"
+                    (and (equal? (arithmetic-shift 1 10) 1024)
+                         (equal? (arithmetic-shift 255 -3) 31)
+                         (equal? (arithmetic-shift 1.0 2) 4)
+                         (equal? (arithmetic-shift 1 2.0) 4)))
               (list "integer-length"
                     (and (equal? (integer-length 8) 4)
                          (equal? (integer-length -8) 3)


### PR DESCRIPTION
## Summary
- implement `arithmetic-shift` in the WebAssembly runtime
- validate inputs with `exact-integer?` before converting flonum arguments
- wire `arithmetic-shift` into the compiler and expose it from `primitives`
- document usage in basic examples

------
https://chatgpt.com/codex/tasks/task_e_68bdd3dce6d8832284540b9dcc07db8c