### PR TITLE
Fix arithmetic-shift negative shift handling

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -4878,8 +4878,8 @@
                   (then (call $raise-expected-number (local.get $m))))
 
               ;; --- Extract values ---
-              (local.set $n/fx (i31.get_u (ref.cast (ref i31) (local.get $n))))
-              (local.set $m/fx (i31.get_u (ref.cast (ref i31) (local.get $m))))
+              (local.set $n/fx (i31.get_s (ref.cast (ref i31) (local.get $n))))
+              (local.set $m/fx (i31.get_s (ref.cast (ref i31) (local.get $m))))
               (local.set $n/i  (i32.shr_s (local.get $n/fx) (i32.const 1)))
               (local.set $m/i  (i32.shr_s (local.get $m/fx) (i32.const 1)))
 


### PR DESCRIPTION
## Summary
- Correct arithmetic-shift to sign-extend arguments, ensuring negative shift counts are handled properly.

## Testing
- `raco test test/test-basics.rkt` *(fails: raco not found)*
- `racket test/test-basics.rkt` *(fails: racket not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfcc58c488322a71384d41db86858