### PR TITLE
Add single-flonum predicates

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -517,6 +517,8 @@
   ; fixnum-for-every-system?
 
   flonum?
+  single-flonum?
+  single-flonum-available?
   fl+ fl- fl* fl/
   fl= fl< fl> fl<= fl>=
   flabs flround flfloor flceiling fltruncate flsingle

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -84,6 +84,8 @@
  exact->inexact
  fixnum?
  flonum?
+ single-flonum?
+ single-flonum-available?
  zero?
  positive?
  negative?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2762,8 +2762,8 @@
         ;; [ ] fixnum?
         ;; [ ] flonum?
         ;; [ ] double-flonum?
-        ;; [ ] single-flonum?
-        ;; [ ] single-flonum-available?
+        ;; [x] single-flonum?
+        ;; [x] single-flonum-available?
         ;; [x] zero?
         ;; [x] positive?
         ;; [x] negative?
@@ -2815,6 +2815,18 @@
                    (ref.test (ref $Flonum) (local.get $z))
                    (then (global.get $true))
                    (else (global.get $false))))
+
+         (func $single-flonum? (type $Prim1)
+               ;; single-flonums are not supported
+               (param $v (ref eq))
+               (result (ref eq))
+               (drop (local.get $v))
+               (global.get $false))
+
+         (func $single-flonum-available? (type $Prim0)
+               ;; single-flonums are not supported
+               (result (ref eq))
+               (global.get $false))
 
          (func $inexact-real? (type $Prim1)
                ;; Returns #t for inexact real numbers (flonums that are not NaN)

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -581,12 +581,19 @@
                          (= (order-of-magnitude 0.009) -3)))))
 
        (list "4.3.3 Flonums"
-             (list
-              (list "flonum?"
-                    (and (equal? (flonum? 1.0) #t)
-                         (equal? (flonum? 1) #f)
-                         (equal? (procedure-arity flonum?) 1)))
-              (list "fl+"
+               (list
+                (list "flonum?"
+                      (and (equal? (flonum? 1.0) #t)
+                           (equal? (flonum? 1) #f)
+                           (equal? (procedure-arity flonum?) 1)))
+                (list "single-flonum?"
+                      (and (equal? (single-flonum? 1.0) #f)
+                           (equal? (single-flonum? 1) #f)
+                           (equal? (procedure-arity single-flonum?) 1)))
+                (list "single-flonum-available?"
+                      (and (equal? (single-flonum-available?) #f)
+                           (equal? (procedure-arity single-flonum-available?) 0)))
+                (list "fl+"
                     (and (fl= (fl+ 1.0 2.0) 3.0)
                          (fl= (fl+ 1.0 2.0 3.0) 6.0)))
               (list "fl-"


### PR DESCRIPTION
## Summary
- implement single-flonum? and single-flonum-available? primitives
- register and export new primitives
- test single-flonum primitives

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `racket test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bdffbccf7c83229966c64cadb4b31b