### PR TITLE
Implement real->double-flonum primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -483,6 +483,7 @@
   inexact?
   inexact->exact
   exact->inexact
+  real->double-flonum
   exact-round exact-floor exact-ceiling exact-truncate
   round floor ceiling truncate
   sin  cos  tan  asin  acos  atan

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -82,6 +82,7 @@
  inexact?
  inexact->exact
  exact->inexact
+ real->double-flonum
  fixnum?
  flonum?
  zero?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2774,7 +2774,7 @@
         ;; [x] inexact->exact
         ;; [x] exact->inexact
         ;; [ ] real->single-flonum
-        ;; [ ] real->double-flonum
+        ;; [x] real->double-flonum
 
          (func $number? (type $Prim1)
                (param $v (ref eq))
@@ -2957,6 +2957,31 @@
 
               ;; Not a number
               (call $raise-expected-number (local.get $z))
+              (unreachable))
+
+
+        (func $real->double-flonum (type $Prim1)
+              (param $x (ref eq))
+              (result   (ref eq))
+
+              (local $bits i32)
+
+              ;; If x is already a flonum, return it
+              (if (ref.test (ref $Flonum) (local.get $x))
+                  (then (return (local.get $x))))
+
+              ;; If x is a fixnum, ensure LSB = 0 and convert
+              (if (ref.test (ref i31) (local.get $x))
+                  (then
+                   (local.set $bits (i31.get_u (ref.cast (ref i31) (local.get $x))))
+                   (if (i32.eqz (i32.and (local.get $bits) (i32.const 1)))
+                       (then (return (struct.new $Flonum (i32.const 0)
+                                                 (f64.convert_i32_s
+                                                  (i32.shr_u (local.get $bits)
+                                                             (i32.const 1)))))))))
+
+              ;; Not a number
+              (call $raise-expected-number (local.get $x))
               (unreachable))
 
 

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -241,6 +241,9 @@
               (list "exact->inexact"
                     (and (equal? (exact->inexact 1)   1.0)
                          (equal? (exact->inexact 1.0) 1.0)))
+              (list "real->double-flonum"
+                    (and (equal? (real->double-flonum 1)   1.0)
+                         (equal? (real->double-flonum 1.0) 1.0)))
               (list "nan?"
                     (and (equal? (nan? +nan.0) #t)
                          (equal? (nan? 0.0)   #f)))


### PR DESCRIPTION
## Summary
- add runtime support for `real->double-flonum`
- expose `real->double-flonum` in primitive lists and exports
- exercise `real->double-flonum` in basics tests

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfff03f9083228a0ff08e5ae4a038