### PR TITLE
Implement double-flonum? primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -519,6 +519,7 @@
   ; fixnum-for-every-system?
 
   flonum?
+  double-flonum?
   single-flonum?
   single-flonum-available?
   fl+ fl- fl* fl/

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -84,8 +84,9 @@
  inexact->exact
  exact->inexact
  real->double-flonum
- fixnum?
+  fixnum?
  flonum?
+ double-flonum?
  single-flonum?
  single-flonum-available?
  zero?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -2760,9 +2760,9 @@
          ;; [x] infinite?
          ;; [x] inexact-real?
          ;; [x] fixnum?
-         ;; [x] flonum?
-         ;; [ ] double-flonum?
-         ;; [x] single-flonum?
+        ;; [x] flonum?
+        ;; [x] double-flonum?
+        ;; [x] single-flonum?
          ;; [x] single-flonum-available?
          ;; [x] zero?
          ;; [x] positive?
@@ -5511,6 +5511,11 @@
                    (ref.test (ref $Flonum) (local.get $a))
                    (then (global.get $true))
                    (else (global.get $false))))
+
+        ;; double-flonum? : (ref eq) -> (ref eq)
+        ;;   All flonums are double precision, so reuse flonum?
+        (func $double-flonum? (type $Prim1) (param $a (ref eq)) (result (ref eq))
+              (call $flonum? (local.get $a)))
 
          (func $fx->fl/precise (param $v (ref eq)) (result (ref $Flonum))
                (local $v/i32 i32)

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -595,6 +595,10 @@
                       (and (equal? (flonum? 1.0) #t)
                            (equal? (flonum? 1) #f)
                            (equal? (procedure-arity flonum?) 1)))
+                (list "double-flonum?"
+                      (and (equal? (double-flonum? 1.0) #t)
+                           (equal? (double-flonum? 1) #f)
+                           (equal? (procedure-arity double-flonum?) 1)))
                 (list "single-flonum?"
                       (and (equal? (single-flonum? 1.0) #f)
                            (equal? (single-flonum? 1) #f)


### PR DESCRIPTION
## Summary
- Add runtime implementation for `double-flonum?` delegating to `flonum?`
- Expose `double-flonum?` through compiler and primitive interfaces
- Cover `double-flonum?` in basic flonum tests

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be046945f48322a428200f44e056d3