### PR TITLE
Implement take-common-prefix primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -416,7 +416,7 @@
   alt-reverse ; used in expansion of for/list
   map andmap ormap count for-each
   list*
-  filter partition remove drop-common-prefix
+  filter partition remove take-common-prefix drop-common-prefix
   make-list
    build-list
    argmax argmin
@@ -3136,6 +3136,7 @@
          [(vector-map!)                (inline-prim/variadic sym ae1 2 2)]
 
           [(remove)                     (inline-prim/optional sym ae1 2 3)]
+          [(take-common-prefix)         (inline-prim/optional sym ae1 2 3)]
           [(drop-common-prefix)         (inline-prim/optional sym ae1 2 3)]
           [(argmax argmin)              (inline-prim/fixed sym ae1 2)]
 

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -371,7 +371,8 @@ bytes->string/utf-8
 filter
 partition
 remove
- drop-common-prefix
+take-common-prefix
+drop-common-prefix
  ; remq
  ; remv
  ; remw

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -11818,6 +11818,84 @@
                (unreachable))
 
 
+        (func $take-common-prefix (type $Prim3)
+              (param $l     (ref eq)) ; list
+              (param $r     (ref eq)) ; list
+              (param $same? (ref eq)) ; optional, defaults to equal?
+              (result       (ref eq))
+
+              (local $lcur   (ref eq))
+              (local $rcur   (ref eq))
+              (local $lpair  (ref $Pair))
+              (local $rpair  (ref $Pair))
+              (local $lelem  (ref eq))
+              (local $relem  (ref eq))
+              (local $acc    (ref eq))
+              (local $args   (ref $Args))
+              (local $res    (ref eq))
+              (local $use-proc i32)
+
+              ;; Handle optional comparator
+              (if (ref.eq (local.get $same?) (global.get $missing))
+                  (then (local.set $use-proc (i32.const 0)))
+                  (else
+                   (if (i32.eqz (ref.test (ref $Procedure) (local.get $same?)))
+                       (then (call $raise-argument-error:procedure-expected (local.get $same?))
+                             (unreachable))
+                       (else))
+                   (local.set $use-proc (i32.const 1))))
+
+              ;; Iterate through lists, building accumulator
+              (local.set $lcur (local.get $l))
+              (local.set $rcur (local.get $r))
+              (local.set $acc (global.get $null))
+              (loop $loop
+                    (if (ref.eq (local.get $lcur) (global.get $null))
+                        (then (return (call $reverse (local.get $acc)))))
+                    (if (ref.eq (local.get $rcur) (global.get $null))
+                        (then (return (call $reverse (local.get $acc)))))
+
+                    (if (i32.eqz (ref.test (ref $Pair) (local.get $lcur)))
+                        (then (call $raise-pair-expected (local.get $lcur))
+                              (unreachable)))
+                    (if (i32.eqz (ref.test (ref $Pair) (local.get $rcur)))
+                        (then (call $raise-pair-expected (local.get $rcur))
+                              (unreachable)))
+
+                    (local.set $lpair (ref.cast (ref $Pair) (local.get $lcur)))
+                    (local.set $rpair (ref.cast (ref $Pair) (local.get $rcur)))
+                    (local.set $lelem (struct.get $Pair $a (local.get $lpair)))
+                    (local.set $relem (struct.get $Pair $a (local.get $rpair)))
+
+                    (block $same
+                           (if (i32.eqz (local.get $use-proc))
+                               (then
+                                (if (ref.eq (call $equal? (local.get $lelem) (local.get $relem))
+                                            (global.get $false))
+                                    (then (return (call $reverse (local.get $acc))))
+                                    (else (br $same))))
+                               (else
+                                (local.set $res
+                                           (call_ref $ProcedureInvoker
+                                                     (ref.cast (ref $Procedure) (local.get $same?))
+                                                     (block (result (ref $Args))
+                                                            (local.set $args (array.new $Args (global.get $null) (i32.const 2)))
+                                                            (array.set $Args (local.get $args) (i32.const 0) (local.get $lelem))
+                                                            (array.set $Args (local.get $args) (i32.const 1) (local.get $relem))
+                                                            (local.get $args))
+                                                     (struct.get $Procedure $invoke
+                                                                (ref.cast (ref $Procedure) (local.get $same?)))))
+                                (if (ref.eq (local.get $res) (global.get $false))
+                                    (then (return (call $reverse (local.get $acc))))
+                                    (else (br $same))))))
+
+                    (local.set $acc (call $cons (local.get $lelem) (local.get $acc)))
+                    (local.set $lcur (struct.get $Pair $d (local.get $lpair)))
+                    (local.set $rcur (struct.get $Pair $d (local.get $rpair)))
+                    (br $loop))
+              (unreachable))
+
+
         (func $drop-common-prefix (type $Prim3)
               (param $l     (ref eq)) ; list
               (param $r     (ref eq)) ; list

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1389,6 +1389,8 @@
         (list "argmin"
               (and (equal? (argmin car '((3 pears) (1 banana) (2 apples))) '(1 banana))
                    (equal? (argmin car '((1 banana) (1 orange))) '(1 banana))))
+        (list "take-common-prefix"
+              (equal? (take-common-prefix '(a b c d) '(a b x y z)) '(a b)))
         (list "drop-common-prefix"
               (let-values ([(l r)
                             (drop-common-prefix '(a b c d) '(a b x y z))])


### PR DESCRIPTION
## Summary
- add `take-common-prefix` primitive to runtime and expose via compiler and primitive exports
- support optional comparator and return longest shared list prefix
- cover common prefix behavior in basic test suite

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be07b2c0908322b5b7685a98f6c486