### PR TITLE
Implement split-common-prefix

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -416,7 +416,7 @@
   alt-reverse ; used in expansion of for/list
   map andmap ormap count for-each
   list*
-  filter partition remove take-common-prefix drop-common-prefix
+  filter partition remove take-common-prefix drop-common-prefix split-common-prefix
   make-list
    build-list
    argmax argmin
@@ -3138,6 +3138,7 @@
           [(remove)                     (inline-prim/optional sym ae1 2 3)]
           [(take-common-prefix)         (inline-prim/optional sym ae1 2 3)]
           [(drop-common-prefix)         (inline-prim/optional sym ae1 2 3)]
+          [(split-common-prefix)        (inline-prim/optional sym ae1 2 3)]
           [(argmax argmin)              (inline-prim/fixed sym ae1 2)]
 
           [(hash-ref)                   (inline-prim/optional sym ae1 2 3)]

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -373,6 +373,7 @@ partition
 remove
 take-common-prefix
 drop-common-prefix
+split-common-prefix
  ; remq
  ; remv
  ; remw

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -11970,6 +11970,87 @@
                     (br $loop))
               (unreachable))
 
+        (func $split-common-prefix (type $Prim3)
+              (param $l     (ref eq)) ; list
+              (param $r     (ref eq)) ; list
+              (param $same? (ref eq)) ; optional, defaults to equal?
+              (result       (ref eq))
+
+              (local $lcur   (ref eq))
+              (local $rcur   (ref eq))
+              (local $lpair  (ref $Pair))
+              (local $rpair  (ref $Pair))
+              (local $lelem  (ref eq))
+              (local $relem  (ref eq))
+              (local $acc    (ref eq))
+              (local $args   (ref $Args))
+              (local $res    (ref eq))
+              (local $use-proc i32)
+
+              ;; Handle optional comparator
+              (if (ref.eq (local.get $same?) (global.get $missing))
+                  (then (local.set $use-proc (i32.const 0)))
+                  (else
+                   (if (i32.eqz (ref.test (ref $Procedure) (local.get $same?)))
+                       (then (call $raise-argument-error:procedure-expected (local.get $same?))
+                             (unreachable))
+                       (else))
+                   (local.set $use-proc (i32.const 1))))
+
+              ;; Iterate through lists, building accumulator and returning tails
+              (local.set $lcur (local.get $l))
+              (local.set $rcur (local.get $r))
+              (local.set $acc (global.get $null))
+              (loop $loop
+                    (if (ref.eq (local.get $lcur) (global.get $null))
+                        (then (return (array.new_fixed $Values 3 (call $reverse (local.get $acc))
+                                                          (local.get $lcur) (local.get $rcur)))))
+                    (if (ref.eq (local.get $rcur) (global.get $null))
+                        (then (return (array.new_fixed $Values 3 (call $reverse (local.get $acc))
+                                                          (local.get $lcur) (local.get $rcur)))))
+
+                    (if (i32.eqz (ref.test (ref $Pair) (local.get $lcur)))
+                        (then (call $raise-pair-expected (local.get $lcur))
+                              (unreachable)))
+                    (if (i32.eqz (ref.test (ref $Pair) (local.get $rcur)))
+                        (then (call $raise-pair-expected (local.get $rcur))
+                              (unreachable)))
+
+                    (local.set $lpair (ref.cast (ref $Pair) (local.get $lcur)))
+                    (local.set $rpair (ref.cast (ref $Pair) (local.get $rcur)))
+                    (local.set $lelem (struct.get $Pair $a (local.get $lpair)))
+                    (local.set $relem (struct.get $Pair $a (local.get $rpair)))
+
+                    (block $same
+                           (if (i32.eqz (local.get $use-proc))
+                               (then
+                                (if (ref.eq (call $equal? (local.get $lelem) (local.get $relem))
+                                            (global.get $false))
+                                    (then (return (array.new_fixed $Values 3 (call $reverse (local.get $acc))
+                                                               (local.get $lcur) (local.get $rcur))))
+                                    (else (br $same))))
+                               (else
+                                (local.set $res
+                                           (call_ref $ProcedureInvoker
+                                                     (ref.cast (ref $Procedure) (local.get $same?))
+                                                     (block (result (ref $Args))
+                                                            (local.set $args (array.new $Args (global.get $null) (i32.const 2)))
+                                                            (array.set $Args (local.get $args) (i32.const 0) (local.get $lelem))
+                                                            (array.set $Args (local.get $args) (i32.const 1) (local.get $relem))
+                                                            (local.get $args))
+                                                     (struct.get $Procedure $invoke
+                                                                (ref.cast (ref $Procedure) (local.get $same?)))))
+                                (if (ref.eq (local.get $res) (global.get $false))
+                                    (then (return (array.new_fixed $Values 3 (call $reverse (local.get $acc))
+                                                               (local.get $lcur) (local.get $rcur))))
+                                    (else (br $same))))))
+
+                    (local.set $acc (call $cons (local.get $lelem) (local.get $acc)))
+                    (local.set $lcur (struct.get $Pair $d (local.get $lpair)))
+                    (local.set $rcur (struct.get $Pair $d (local.get $rpair)))
+                    (br $loop))
+              (unreachable))
+
 
 
 

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1396,6 +1396,12 @@
                             (drop-common-prefix '(a b c d) '(a b x y z))])
                 (and (equal? l '(c d))
                      (equal? r '(x y z)))))
+        (list "split-common-prefix"
+              (let-values ([(p l r)
+                            (split-common-prefix '(a b c d) '(a b x y z))])
+                (and (equal? p '(a b))
+                     (equal? l '(c d))
+                     (equal? r '(x y z)))))
         ))
 
  (list "4.12 Vectors"


### PR DESCRIPTION
## Summary
- add split-common-prefix primitive returning common prefix and remaining tails
- wire split-common-prefix into compiler and primitive lists


------
https://chatgpt.com/codex/tasks/task_e_68be09b47a9c8322af76c3d2e967e2f8