### PR TITLE
Implement list-set primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -408,7 +408,7 @@
   pair? cons? null? empty?
   cons car cdr
   list              ; not first order yet
-  list? length list-ref list-tail
+  list? length list-ref list-tail list-set
   first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth last last-pair
   append ; variadic list primitive
   flatten

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -339,6 +339,7 @@ bytes->string/utf-8
  length
  list-ref
  list-tail
+ list-set
  first
  second
  third

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -10274,11 +10274,14 @@
                              (global.get $false)      ;; a = null
                              (global.get $false)))    ;; d = null
          
-         ;; Pair related exceptions         
-         (func $raise-pair-expected (param $x (ref eq)) (unreachable))
-         (func $raise-bad-list-ref-index
-               (param $xs  (ref $Pair)) (param $i   i32) (param $len i32)
-               (unreachable))
+        ;; Pair related exceptions
+        (func $raise-pair-expected (param $x (ref eq)) (unreachable))
+        (func $raise-bad-list-ref-index
+              (param $xs  (ref $Pair)) (param $i   i32) (param $len i32)
+              (unreachable))
+        (func $raise-bad-list-set-index
+              (param $xs (ref eq)) (param $i i32) (param $len i32)
+              (unreachable))
           (func $pair? (type $Prim1) (param $v (ref eq)) (result (ref eq))
                 (if (result (ref eq)) (ref.test (ref $Pair) (local.get $v))
                     (then (global.get $true))
@@ -10533,6 +10536,93 @@
                     (unreachable)))
 
                (call $list-tail/checked (local.get $pair) (local.get $idx)))
+
+        ;; list-set/checked: xs is a Pair and i >= 0 within bounds.
+        ;; Returns a new list with the element at index i replaced by v.
+        (func $list-set/checked
+              (param $xs (ref $Pair)) (param $i i32) (param $v (ref eq))
+              (result (ref eq))
+              (local $p      (ref $Pair))
+              (local $k      i32)
+              (local $next   (ref eq))
+              (local $rev    (ref eq))
+              (local $len    i32)
+              (local $tail   (ref eq))
+              (local $res    (ref eq))
+              (local $prefix (ref eq))
+
+              (local.set $p (local.get $xs))
+              (local.set $k (local.get $i))
+              (local.set $rev (global.get $null))
+
+              (loop $loop
+                    (if (i32.eqz (local.get $k))
+                        (then
+                         (local.set $tail (struct.get $Pair $d (local.get $p)))
+                         (local.set $res
+                                    (struct.new $Pair (i32.const 0)
+                                                (local.get $v) (local.get $tail)))
+                         (local.set $prefix (local.get $rev))
+                         (loop $rebuild
+                               (if (ref.eq (local.get $prefix) (global.get $null))
+                                   (then (return (local.get $res))))
+                               (local.set $res
+                                          (struct.new $Pair (i32.const 0)
+                                                      (struct.get $Pair $a
+                                                                  (ref.cast (ref $Pair)
+                                                                            (local.get $prefix)))
+                                                      (local.get $res)))
+                               (local.set $prefix
+                                          (struct.get $Pair $d
+                                                      (ref.cast (ref $Pair)
+                                                                (local.get $prefix))))
+                               (br $rebuild)))
+                    (local.set $rev
+                               (struct.new $Pair (i32.const 0)
+                                           (struct.get $Pair $a (local.get $p))
+                                           (local.get $rev)))
+                    (local.set $next (struct.get $Pair $d (local.get $p)))
+                    (if (ref.test (ref $Pair) (local.get $next))
+                        (then
+                         (local.set $p (ref.cast (ref $Pair) (local.get $next)))
+                         (local.set $k (i32.sub (local.get $k) (i32.const 1)))
+                         (br $loop))
+                        (else
+                         (local.set $len
+                                    (i32.add (i32.sub (local.get $i) (local.get $k))
+                                             (i32.const 1)))
+                         (call $raise-bad-list-set-index
+                               (local.get $xs) (local.get $i) (local.get $len))
+                         (unreachable))))
+
+              (unreachable))
+
+        (func $list-set (type $Prim3)
+              (param $xs (ref eq)) (param $i (ref eq)) (param $v (ref eq))
+              (result (ref eq))
+              (local $idx  i32)
+              (local $pair (ref $Pair))
+
+              ;; Decode & check fixnum index
+              (if (ref.test (ref i31) (local.get $i))
+                  (then
+                   (local.set $idx (i31.get_u (ref.cast (ref i31) (local.get $i))))
+                   (if (i32.ne (i32.and (local.get $idx) (i32.const 1)) (i32.const 0))
+                       (then (call $raise-check-fixnum (local.get $i))))
+                   (local.set $idx (i32.shr_u (local.get $idx) (i32.const 1))))
+                  (else (call $raise-check-fixnum (local.get $i))))
+
+              ;; Ensure non-empty proper list
+              (if (ref.eq (local.get $xs) (global.get $null))
+                  (then
+                   (call $raise-bad-list-set-index
+                         (local.get $xs) (local.get $idx) (i32.const 0))
+                   (unreachable)))
+              (if (ref.eq (call $list? (local.get $xs)) (global.get $false))
+                  (then (call $raise-argument-error (local.get $xs)) (unreachable)))
+
+              (local.set $pair (ref.cast (ref $Pair) (local.get $xs)))
+              (call $list-set/checked (local.get $pair) (local.get $idx) (local.get $v)))
 
 
          (func $append (type $Prim>=0)

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1258,6 +1258,10 @@
                    (equal? (list-tail 1 0)             1)
                    (equal? (procedure-arity list-tail) 2)))
 
+        (list "list-set"
+              (and (equal? (list-set '(a b c d) 2 'x) '(a b x d))
+                   (equal? (procedure-arity list-set) 3)))
+
         (list "first"
               (and (equal? (first '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)) 1)
                    (equal? (procedure-arity first) 1)))


### PR DESCRIPTION
## Summary
- add runtime implementation for `list-set`
- expose `list-set` as a primitive
- test basic `list-set` behavior

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found: raco)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be09ea5f3083229938c10773c1039d