### PR TITLE
Implement Unicode character classification primitives

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -548,11 +548,29 @@ var imports = {
       }),
       'char_foldcase': ((cp) => {
         // Note: JavaScript doesn't have builtin unicode aware fold case (year 2025).
-        //       For now, we will just use lowercase.                  
+        //       For now, we will just use lowercase.
         const s = String.fromCodePoint(cp).toLowerCase();
         const arr = Array.from(s);
         return (arr.length === 1) ? arr[0].codePointAt(0) : cp;
-      })
+      }),
+      'char_alphabetic': ((cp) =>
+        Number(/\p{Alphabetic}/u.test(String.fromCodePoint(cp)))),
+      'char_lower_case': ((cp) =>
+        Number(/\p{Lowercase}/u.test(String.fromCodePoint(cp)))),
+      'char_upper_case': ((cp) =>
+        Number(/\p{Uppercase}/u.test(String.fromCodePoint(cp)))),
+      'char_title_case': ((cp) =>
+        Number(/\p{gc=Lt}/u.test(String.fromCodePoint(cp)))),
+      'char_numeric': ((cp) =>
+        Number(/\p{Number}/u.test(String.fromCodePoint(cp)))),
+      'char_symbolic': ((cp) =>
+        Number(/\p{gc=Sm}|\p{gc=Sc}|\p{gc=Sk}|\p{gc=So}/u.test(String.fromCodePoint(cp)))),
+      'char_punctuation': ((cp) =>
+        Number(/\p{gc=Pc}|\p{gc=Pd}|\p{gc=Ps}|\p{gc=Pe}|\p{gc=Pi}|\p{gc=Pf}|\p{gc=Po}/u.test(String.fromCodePoint(cp)))),
+      'char_graphic': ((cp) =>
+        Number(/\p{gc=Ll}|\p{gc=Lm}|\p{gc=Lo}|\p{gc=Lt}|\p{gc=Lu}|\p{gc=Nd}|\p{gc=Nl}|\p{gc=No}|\p{gc=Mn}|\p{gc=Mc}|\p{gc=Me}|\p{Alphabetic}|\p{Number}|\p{gc=Sm}|\p{gc=Sc}|\p{gc=Sk}|\p{gc=So}|\p{gc=Pc}|\p{gc=Pd}|\p{gc=Ps}|\p{gc=Pe}|\p{gc=Pi}|\p{gc=Pf}|\p{gc=Po}/u.test(String.fromCodePoint(cp)))),
+      'char_extended_pictographic': ((cp) =>
+        Number(/\p{Extended_Pictographic}/u.test(String.fromCodePoint(cp))))
     },
     'standard': {
       'global-this':               (() => globalThis),

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -455,8 +455,19 @@
   char-ci>?           ; variadic
   char-ci>=?          ; variadic
   ; char predicates
+  char-alphabetic?
+  char-lower-case?
+  char-upper-case?
+  char-title-case?
+  char-numeric?
+  char-symbolic?
+  char-punctuation?
+  char-graphic?
   char-whitespace?
-  
+  char-blank?
+  char-iso-control?
+  char-extended-pictographic?
+
   eq?
   eqv?
   equal?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -296,7 +296,9 @@ bytes->string/utf-8
  char=? char<? char<=? char>? char>=?
  char-downcase char-foldcase char-titlecase char-upcase
  char-ci=? char-ci<? char-ci<=? char-ci>? char-ci>=?
- char-whitespace?
+ char-alphabetic? char-lower-case? char-upper-case? char-title-case?
+ char-numeric? char-symbolic? char-punctuation? char-graphic?
+ char-whitespace? char-blank? char-iso-control? char-extended-pictographic?
 
  ;; 4.7 Symbols
  symbol?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -645,6 +645,42 @@
                (import "primitives" "char_foldcase")
                (param i32) (result i32))
 
+        (func $char-alphabetic?/ucs
+              (import "primitives" "char_alphabetic")
+              (param i32) (result i32))
+
+        (func $char-lower-case?/ucs
+              (import "primitives" "char_lower_case")
+              (param i32) (result i32))
+
+        (func $char-upper-case?/ucs
+              (import "primitives" "char_upper_case")
+              (param i32) (result i32))
+
+        (func $char-title-case?/ucs
+              (import "primitives" "char_title_case")
+              (param i32) (result i32))
+
+        (func $char-numeric?/ucs
+              (import "primitives" "char_numeric")
+              (param i32) (result i32))
+
+        (func $char-symbolic?/ucs
+              (import "primitives" "char_symbolic")
+              (param i32) (result i32))
+
+        (func $char-punctuation?/ucs
+              (import "primitives" "char_punctuation")
+              (param i32) (result i32))
+
+        (func $char-graphic?/ucs
+              (import "primitives" "char_graphic")
+              (param i32) (result i32))
+
+        (func $char-extended-pictographic?/ucs
+              (import "primitives" "char_extended_pictographic")
+              (param i32) (result i32))
+
         ;; Math functions
         (func $js-math-abs
               (import "math" "abs")
@@ -9739,6 +9775,34 @@
 
         ;; 4.6.3 Classifications
 
+        ,@(for/list ([(name imp)
+                      (in-list '(( $char-alphabetic?    $char-alphabetic?/ucs)
+                                 ( $char-lower-case?    $char-lower-case?/ucs)
+                                 ( $char-upper-case?    $char-upper-case?/ucs)
+                                 ( $char-title-case?    $char-title-case?/ucs)
+                                 ( $char-numeric?       $char-numeric?/ucs)
+                                 ( $char-symbolic?      $char-symbolic?/ucs)
+                                 ( $char-punctuation?   $char-punctuation?/ucs)
+                                 ( $char-graphic?       $char-graphic?/ucs)))]
+            `(func ,name (type $Prim1) (param $c (ref eq)) (result (ref eq))
+                   (local $i31   (ref i31))
+                   (local $c/tag i32)
+                   (local $cp    i32)
+                   ;; Type check
+                   (if (i32.eqz (ref.test (ref i31) (local.get $c)))
+                       (then (call $raise-check-char (local.get $c))))
+                   (local.set $i31   (ref.cast (ref i31) (local.get $c)))
+                   (local.set $c/tag (i31.get_u (local.get $i31)))
+                   ;; Decode codepoint
+                   (if (i32.ne (i32.and (local.get $c/tag)
+                                        (i32.const ,char-mask))
+                               (i32.const ,char-tag))
+                       (then (call $raise-check-char (local.get $c))))
+                   (local.set $cp (i32.shr_u (local.get $c/tag) (i32.const ,char-shift)))
+                   (if (i32.eqz (call ,imp (local.get $cp)))
+                       (then (global.get $false))
+                       (else (global.get $true)))))
+
         (func $char-whitespace? (type $Prim1) (param $c (ref eq)) (result (ref eq))
               (local $i31   (ref i31))
               (local $c/tag i32)
@@ -9756,7 +9820,7 @@
               (local.set $cp (i32.shr_u (local.get $c/tag) (i32.const ,char-shift)))
               ;; Delegate
               (call $char-whitespace?/ucs (local.get $cp)))
-        
+
         (func $char-whitespace?/ucs (param $cp i32) (result (ref eq))
               (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\space)))
                   (then (return (global.get $true))))
@@ -9785,6 +9849,86 @@
               (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\u3000))) ; IDEOGRAPHIC SPACE
                   (then (return (global.get $true))))
               (global.get $false))
+
+        (func $char-blank? (type $Prim1) (param $c (ref eq)) (result (ref eq))
+              (local $i31   (ref i31))
+              (local $c/tag i32)
+              (local $cp    i32)
+              ;; Type check
+              (if (i32.eqz (ref.test (ref i31) (local.get $c)))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $i31   (ref.cast (ref i31) (local.get $c)))
+              (local.set $c/tag (i31.get_u (local.get $i31)))
+              ;; Decode codepoint
+              (if (i32.ne (i32.and (local.get $c/tag)
+                                   (i32.const ,char-mask))
+                          (i32.const ,char-tag))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $cp (i32.shr_u (local.get $c/tag) (i32.const ,char-shift)))
+              ;; Delegate
+              (call $char-blank?/ucs (local.get $cp)))
+
+        (func $char-blank?/ucs (param $cp i32) (result (ref eq))
+              (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\tab)))
+                  (then (return (global.get $true))))
+              (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\space)))
+                  (then (return (global.get $true))))
+              (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\u00A0)))
+                  (then (return (global.get $true))))
+              (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\u1680)))
+                  (then (return (global.get $true))))
+              ;; U+2000–U+200A
+              (if (i32.le_u (local.get $cp) (i32.const ,(char->integer #\u200A)))
+                  (then (if (i32.ge_u (local.get $cp) (i32.const ,(char->integer #\u2000)))
+                            (then (return (global.get $true))))))
+              (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\u202F)))
+                  (then (return (global.get $true))))
+              (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\u205F)))
+                  (then (return (global.get $true))))
+              (if (i32.eq (local.get $cp) (i32.const ,(char->integer #\u3000)))
+                  (then (return (global.get $true))))
+              (global.get $false))
+
+        (func $char-iso-control? (type $Prim1) (param $c (ref eq)) (result (ref eq))
+              (local $i31   (ref i31))
+              (local $c/tag i32)
+              (local $cp    i32)
+              ;; Type check
+              (if (i32.eqz (ref.test (ref i31) (local.get $c)))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $i31   (ref.cast (ref i31) (local.get $c)))
+              (local.set $c/tag (i31.get_u (local.get $i31)))
+              ;; Decode codepoint
+              (if (i32.ne (i32.and (local.get $c/tag)
+                                   (i32.const ,char-mask))
+                          (i32.const ,char-tag))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $cp (i32.shr_u (local.get $c/tag) (i32.const ,char-shift)))
+              (if (i32.le_u (local.get $cp) (i32.const ,(char->integer #\u001F)))
+                  (then (return (global.get $true))))
+              (if (i32.le_u (local.get $cp) (i32.const ,(char->integer #\u009F)))
+                  (then (if (i32.ge_u (local.get $cp) (i32.const ,(char->integer #\rubout)))
+                            (then (return (global.get $true))))))
+              (global.get $false))
+
+        (func $char-extended-pictographic? (type $Prim1) (param $c (ref eq)) (result (ref eq))
+              (local $i31   (ref i31))
+              (local $c/tag i32)
+              (local $cp    i32)
+              ;; Type check
+              (if (i32.eqz (ref.test (ref i31) (local.get $c)))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $i31   (ref.cast (ref i31) (local.get $c)))
+              (local.set $c/tag (i31.get_u (local.get $i31)))
+              ;; Decode codepoint
+              (if (i32.ne (i32.and (local.get $c/tag)
+                                   (i32.const ,char-mask))
+                          (i32.const ,char-tag))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $cp (i32.shr_u (local.get $c/tag) (i32.const ,char-shift)))
+              (if (i32.eqz (call $char-extended-pictographic?/ucs (local.get $cp)))
+                  (then (global.get $false))
+                  (else (global.get $true))))
 
         ;; 4.6.4 Character Conversions
 

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1043,11 +1043,67 @@
               (and (equal? (char>=? #\B #\A) #t)
                    (equal? (char>=? #\A #\b) #f)))
 
+        (list "char-alphabetic?"
+              (and (equal? (char-alphabetic? #\A) #t)
+                   (equal? (char-alphabetic? #\1) #f)
+                   (equal? (procedure-arity char-alphabetic?) 1)))
+
+        (list "char-lower-case?"
+              (and (equal? (char-lower-case? #\a) #t)
+                   (equal? (char-lower-case? #\A) #f)
+                   (equal? (procedure-arity char-lower-case?) 1)))
+
+        (list "char-upper-case?"
+              (and (equal? (char-upper-case? #\A) #t)
+                   (equal? (char-upper-case? #\a) #f)
+                   (equal? (procedure-arity char-upper-case?) 1)))
+
+        (list "char-title-case?"
+              (and (equal? (char-title-case? (integer->char #x01C5)) #t)
+                   (equal? (char-title-case? #\A) #f)
+                   (equal? (procedure-arity char-title-case?) 1)))
+
+        (list "char-numeric?"
+              (and (equal? (char-numeric? #\1) #t)
+                   (equal? (char-numeric? #\A) #f)
+                   (equal? (procedure-arity char-numeric?) 1)))
+
+        (list "char-symbolic?"
+              (and (equal? (char-symbolic? #\+) #t)
+                   (equal? (char-symbolic? #\A) #f)
+                   (equal? (procedure-arity char-symbolic?) 1)))
+
+        (list "char-punctuation?"
+              (and (equal? (char-punctuation? #\,) #t)
+                   (equal? (char-punctuation? #\A) #f)
+                   (equal? (procedure-arity char-punctuation?) 1)))
+
+        (list "char-graphic?"
+              (and (equal? (char-graphic? #\A) #t)
+                   (equal? (char-graphic? #\space) #f)
+                   (equal? (procedure-arity char-graphic?) 1)))
+
         (list "char-whitespace?"
               (and (equal? (char-whitespace? #\space) #t)
                    (equal? (char-whitespace? #\tab) #t)
                    (equal? (char-whitespace? #\A) #f)
                    (equal? (procedure-arity char-whitespace?) 1)))
+
+        (list "char-blank?"
+              (and (equal? (char-blank? #\space) #t)
+                   (equal? (char-blank? #\newline) #f)
+                   (equal? (procedure-arity char-blank?) 1)))
+
+        (list "char-iso-control?"
+              (and (equal? (char-iso-control? #\nul) #t)
+                   (equal? (char-iso-control? #\space) #f)
+                   (equal? (procedure-arity char-iso-control?) 1)))
+
+        (list "char-extended-pictographic?"
+              (and (equal? (char-extended-pictographic? (integer->char #x1F600)) #t)
+                   (equal? (char-extended-pictographic? #\A) #f)
+                   (equal? (procedure-arity char-extended-pictographic?) 1)))
+
         (list "char-upcase"
               (and (equal? (char-upcase #\a) #\A)
                    (equal? (char-upcase #\u03BB) #\u039B)


### PR DESCRIPTION
## Summary
- support Unicode-derived predicates like `char-alphabetic?`, `char-numeric?`, `char-symbolic?`, and more
- add missing classification helpers for blank, ISO control, graphic, and extended pictographic characters
- extend tests for new character predicates

## Testing
- `racket test/completion.rkt` *(fails: command not found)*
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf32184b60832295a027302dbb4669