### PR TITLE
Implement char-grapheme-break-property primitive

### DIFF
--- a/assembler.rkt
+++ b/assembler.rkt
@@ -548,10 +548,40 @@ var imports = {
       }),
       'char_foldcase': ((cp) => {
         // Note: JavaScript doesn't have builtin unicode aware fold case (year 2025).
-        //       For now, we will just use lowercase.                  
+        //       For now, we will just use lowercase.
         const s = String.fromCodePoint(cp).toLowerCase();
         const arr = Array.from(s);
         return (arr.length === 1) ? arr[0].codePointAt(0) : cp;
+      }),
+      'char_grapheme_break_property': (cp => {
+        if (cp === 0x000D) return 1; // CR
+        if (cp === 0x000A) return 2; // LF
+        if ((cp >= 0x0000 && cp <= 0x001F && cp !== 0x000A && cp !== 0x000D) ||
+            (cp >= 0x007F && cp <= 0x009F)) return 3; // Control
+        if ((cp >= 0x0300 && cp <= 0x036F) ||
+            (cp >= 0x1AB0 && cp <= 0x1AFF) ||
+            (cp >= 0x1DC0 && cp <= 0x1DFF) ||
+            (cp >= 0x20D0 && cp <= 0x20FF) ||
+            (cp >= 0xFE20 && cp <= 0xFE2F) ||
+            cp === 0x200C) return 4; // Extend
+        if (cp === 0x200D) return 5; // ZWJ
+        if (cp >= 0x1F1E6 && cp <= 0x1F1FF) return 6; // Regional Indicator
+        if ((cp >= 0x0600 && cp <= 0x0605) || cp === 0x06DD || cp === 0x070F || cp === 0x08E2)
+          return 7; // Prepend (subset)
+        if (cp === 0x0903 || cp === 0x093B ||
+            (cp >= 0x093E && cp <= 0x0940) ||
+            (cp >= 0x0949 && cp <= 0x094C) ||
+            (cp >= 0x094E && cp <= 0x094F) ||
+            (cp >= 0x0982 && cp <= 0x0983))
+          return 8; // SpacingMark (subset)
+        if ((cp >= 0x1100 && cp <= 0x115F) || (cp >= 0xA960 && cp <= 0xA97C)) return 9; // L
+        if ((cp >= 0x1160 && cp <= 0x11A7) || (cp >= 0xD7B0 && cp <= 0xD7C6)) return 10; // V
+        if ((cp >= 0x11A8 && cp <= 0x11FF) || (cp >= 0xD7CB && cp <= 0xD7FB)) return 11; // T
+        if (cp >= 0xAC00 && cp <= 0xD7A3) {
+          const sIndex = cp - 0xAC00;
+          return (sIndex % 28 === 0) ? 12 : 13; // LV or LVT
+        }
+        return 0; // Other
       })
     },
     'standard': {

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -456,6 +456,7 @@
   char-ci>=?          ; variadic
   ; char predicates
   char-whitespace?
+  char-grapheme-break-property
   
   eq?
   eqv?

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -296,7 +296,7 @@ bytes->string/utf-8
  char=? char<? char<=? char>? char>=?
  char-downcase char-foldcase char-titlecase char-upcase
  char-ci=? char-ci<? char-ci<=? char-ci>? char-ci>=?
- char-whitespace?
+ char-whitespace? char-grapheme-break-property
 
  ;; 4.7 Symbols
  symbol?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -192,6 +192,20 @@
     ;; String and symbol constants used in the runtime
     (add-runtime-symbol-constant 'racket)
     (add-runtime-symbol-constant 'racket/primitive)
+    (add-runtime-symbol-constant 'Other)
+    (add-runtime-symbol-constant 'CR)
+    (add-runtime-symbol-constant 'LF)
+    (add-runtime-symbol-constant 'Control)
+    (add-runtime-symbol-constant 'Extend)
+    (add-runtime-symbol-constant 'ZWJ)
+    (add-runtime-symbol-constant 'Regional_Indicator)
+    (add-runtime-symbol-constant 'Prepend)
+    (add-runtime-symbol-constant 'SpacingMark)
+    (add-runtime-symbol-constant 'L)
+    (add-runtime-symbol-constant 'V)
+    (add-runtime-symbol-constant 'T)
+    (add-runtime-symbol-constant 'LV)
+    (add-runtime-symbol-constant 'LVT)
     
     (add-runtime-string-constant 'hash-variable-reference   "#<variable-reference>")
     (add-runtime-string-constant 'box-prefix                "#&")
@@ -644,6 +658,10 @@
          (func $char-foldcase/ucs
                (import "primitives" "char_foldcase")
                (param i32) (result i32))
+
+        (func $char-grapheme-break-property/ucs
+              (import "primitives" "char_grapheme_break_property")
+              (param i32) (result i32))
 
         ;; Math functions
         (func $js-math-abs
@@ -9738,6 +9756,54 @@
                    (global.get $true)))
 
         ;; 4.6.3 Classifications
+
+        (func $char-grapheme-break-property (type $Prim1) (param $c (ref eq)) (result (ref eq))
+              (local $i31   (ref i31))
+              (local $c/tag i32)
+              (local $cp    i32)
+              (local $prop  i32)
+              ;; Type check
+              (if (i32.eqz (ref.test (ref i31) (local.get $c)))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $i31   (ref.cast (ref i31) (local.get $c)))
+              (local.set $c/tag (i31.get_u (local.get $i31)))
+              ;; Decode codepoint
+              (if (i32.ne (i32.and (local.get $c/tag)
+                                   (i32.const ,char-mask))
+                          (i32.const ,char-tag))
+                  (then (call $raise-check-char (local.get $c))))
+              (local.set $cp (i32.shr_u (local.get $c/tag) (i32.const ,char-shift)))
+              ;; Delegate to host
+              (local.set $prop
+                         (call $char-grapheme-break-property/ucs (local.get $cp)))
+              (block $ret (result (ref eq))
+                (if (i32.eq (local.get $prop) (i32.const 1))
+                    (then (br $ret (global.get $symbol:CR))))
+                (if (i32.eq (local.get $prop) (i32.const 2))
+                    (then (br $ret (global.get $symbol:LF))))
+                (if (i32.eq (local.get $prop) (i32.const 3))
+                    (then (br $ret (global.get $symbol:Control))))
+                (if (i32.eq (local.get $prop) (i32.const 4))
+                    (then (br $ret (global.get $symbol:Extend))))
+                (if (i32.eq (local.get $prop) (i32.const 5))
+                    (then (br $ret (global.get $symbol:ZWJ))))
+                (if (i32.eq (local.get $prop) (i32.const 6))
+                    (then (br $ret (global.get $symbol:Regional_Indicator))))
+                (if (i32.eq (local.get $prop) (i32.const 7))
+                    (then (br $ret (global.get $symbol:Prepend))))
+                (if (i32.eq (local.get $prop) (i32.const 8))
+                    (then (br $ret (global.get $symbol:SpacingMark))))
+                (if (i32.eq (local.get $prop) (i32.const 9))
+                    (then (br $ret (global.get $symbol:L))))
+                (if (i32.eq (local.get $prop) (i32.const 10))
+                    (then (br $ret (global.get $symbol:V))))
+                (if (i32.eq (local.get $prop) (i32.const 11))
+                    (then (br $ret (global.get $symbol:T))))
+                (if (i32.eq (local.get $prop) (i32.const 12))
+                    (then (br $ret (global.get $symbol:LV))))
+                (if (i32.eq (local.get $prop) (i32.const 13))
+                    (then (br $ret (global.get $symbol:LVT))))
+                (br $ret (global.get $symbol:Other))))
 
         (func $char-whitespace? (type $Prim1) (param $c (ref eq)) (result (ref eq))
               (local $i31   (ref i31))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1048,6 +1048,14 @@
                    (equal? (char-whitespace? #\tab) #t)
                    (equal? (char-whitespace? #\A) #f)
                    (equal? (procedure-arity char-whitespace?) 1)))
+        (list "char-grapheme-break-property"
+              (and (equal? (char-grapheme-break-property #\a) 'Other)
+                   (equal? (char-grapheme-break-property #\return) 'CR)
+                   (equal? (char-grapheme-break-property #\newline) 'LF)
+                   (equal? (char-grapheme-break-property #\u0300) 'Extend)
+                   (equal? (char-grapheme-break-property #\u200D) 'ZWJ)
+                   (equal? (char-grapheme-break-property #\u1F1E6) 'Regional_Indicator)
+                   (equal? (procedure-arity char-grapheme-break-property) 1)))
         (list "char-upcase"
               (and (equal? (char-upcase #\a) #\A)
                    (equal? (char-upcase #\u03BB) #\u039B)


### PR DESCRIPTION
## Summary
- add runtime support for `char-grapheme-break-property`
- expose `char-grapheme-break-property` through compiler and primitives
- provide basic tests for grapheme break property

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf325959a88322aebe78f61ea1b2db