### PR TITLE
Add char-utf-8-length primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -437,6 +437,7 @@
   char?
   char->integer
   integer->char
+  char-utf-8-length
   ; comparisons
   char=?           ; variadic
   char<?           ; variadic

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -295,7 +295,7 @@ bytes=?
 bytes->string/utf-8
 
  ;; 4.6 Characters
- char? char->integer integer->char
+ char? char->integer integer->char char-utf-8-length
  char=? char<? char<=? char>? char>=?
  char-downcase char-foldcase char-titlecase char-upcase
  char-ci=? char-ci<? char-ci<=? char-ci>? char-ci>=?

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -9711,7 +9711,26 @@
                ;; Pack as character: (k << (char-shift - 1)) | char-tag
                (ref.i31 (i32.or (i32.shl (local.get $k/i32) 
                                          (i32.const ,char-shift))
-                                (i32.const ,char-tag))))
+                               (i32.const ,char-tag))))
+
+         (func $char-utf-8-length (type $Prim1) (param $c (ref eq)) (result (ref eq))
+               (local $cp  i32)
+               (local $len i32)
+               ;; Returns bytes needed to encode $c in UTF-8.
+               ;; Characters are limited to U+10FFFF so result is in [1,4].
+               (local.set $cp (call $char->integer/i32 (local.get $c)))
+               (local.set $len
+                     (if (result i32)
+                         (i32.le_u (local.get $cp) (i32.const #x7F))
+                         (i32.const 1)
+                         (if (result i32)
+                             (i32.le_u (local.get $cp) (i32.const #x7FF))
+                             (i32.const 2)
+                             (if (result i32)
+                                 (i32.le_u (local.get $cp) (i32.const #xFFFF))
+                                 (i32.const 3)
+                                 (i32.const 4)))))
+               (ref.i31 (i32.shl (local.get $len) (i32.const 1))))
 
          ;; 4.6.2 Character Comparisons
 

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1022,6 +1022,13 @@
                    (equal? (integer->char 32) #\space)
                    (equal? (procedure-arity integer->char) 1)))
 
+        (list "char-utf-8-length"
+              (and (equal? (char-utf-8-length #\A) 1)
+                   (equal? (char-utf-8-length (integer->char #x07FF)) 2)
+                   (equal? (char-utf-8-length (integer->char #x0800)) 3)
+                   (equal? (char-utf-8-length (integer->char #x10000)) 4)
+                   (equal? (procedure-arity char-utf-8-length) 1)))
+
         (list "char=?"
               (and (equal? (char=? #\A #\A) #t)
                    (equal? (char=? #\A #\B) #f)


### PR DESCRIPTION
## Summary
- implement `char-utf-8-length` in the runtime and expose it through the compiler and primitives interface
- exercise `char-utf-8-length` in basic character tests

## Testing
- `raco test test/test-basics.rkt` *(fails: raco not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf46a966cc8322a91ebae831640743