### PR TITLE
Add filter-not primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -417,7 +417,7 @@
   map andmap ormap count for-each
   list*
   cartesian-product
-  filter partition remove take-common-prefix drop-common-prefix split-common-prefix
+  filter filter-not partition remove take-common-prefix drop-common-prefix split-common-prefix
   make-list
    build-list
    argmax argmin

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -380,6 +380,7 @@ bytes->string/utf-8
  ; foldr
 
 filter
+filter-not
 partition
 remove
 take-common-prefix

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1427,6 +1427,10 @@
               (and (equal? (filter (λ (x) (positive? x)) '(1 -2 3 4 -5)) '(1 3 4))
                    (equal? (filter (λ (x) (positive? x)) '()) '())))
 
+        (list "filter-not"
+              (and (equal? (filter-not (λ (x) (positive? x)) '(1 -2 3 4 -5)) '(-2 -5))
+                   (equal? (filter-not (λ (x) (positive? x)) '()) '())))
+
         (list "partition"
               (and (let-values ([(pos neg)
                                  (partition (λ (x) (positive? x)) '(1 -2 3 4 -5))])


### PR DESCRIPTION
## Summary
- add `filter-not` primitive to runtime and compiler
- export `filter-not` and test list filtering behavior

## Testing
- `racket test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf550805b883229f3c2c896d01456f