### PR TITLE
Implement filter-map primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -417,7 +417,7 @@
   map andmap ormap count for-each
   list*
   cartesian-product
-  filter filter-not partition remove take-common-prefix drop-common-prefix split-common-prefix
+  filter filter-map filter-not partition remove take-common-prefix drop-common-prefix split-common-prefix
   make-list
    build-list
    argmax argmin

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -380,6 +380,7 @@ bytes->string/utf-8
  ; foldr
 
 filter
+filter-map
 filter-not
 partition
 remove

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -12316,6 +12316,157 @@
                      (br $loop))
                (unreachable))
 
+         (func $filter-map (type $Prim>=1)
+               (param $proc (ref eq))   ;; procedure
+               (param $xss  (ref eq))   ;; list of lists
+               (result      (ref eq))
+
+               (local $f      (ref $Procedure))
+               (local $finv   (ref $ProcedureInvoker))
+               (local $outer  (ref eq))
+               (local $pair   (ref $Pair))
+               (local $elem   (ref eq))
+               (local $nlists i32)
+
+               (local $lists  (ref $Args))  ;; cursors for each list
+               (local $call   (ref $Args))  ;; args for f (length = nlists)
+               (local $i      i32)
+               (local $cur    (ref eq))
+               (local $stop   i32)
+
+               (local $acc    (ref eq))     ;; reversed accumulator
+               (local $res    (ref eq))     ;; final result
+               (local $r      (ref eq))
+
+               ;; 1) Check that $proc is a procedure and fetch its invoker
+               (if (i32.eqz (ref.test (ref $Procedure) (local.get $proc)))
+                   (then (call $raise-argument-error:procedure-expected (local.get $proc))
+                         (unreachable)))
+               (local.set $f    (ref.cast (ref $Procedure) (local.get $proc)))
+               (local.set $finv (struct.get $Procedure $invoke (local.get $f)))
+
+               ;; 2) Walk outer list xss to count #lists; ensure xss is proper and each element is a list head
+               (local.set $nlists (i32.const 0))
+               (local.set $outer  (local.get $xss))
+               (block $count_done
+                      (loop $count
+                            (if (ref.eq (local.get $outer) (global.get $null))
+                                (then (br $count_done)))
+                            (if (i32.eqz (ref.test (ref $Pair) (local.get $outer)))
+                                (then (call $raise-pair-expected (local.get $outer)) (unreachable)))
+                            (local.set $pair (ref.cast (ref $Pair) (local.get $outer)))
+                            (local.set $elem (struct.get $Pair $a (local.get $pair)))
+                            (if (i32.eqz
+                                 (i32.or
+                                  (ref.eq (local.get $elem) (global.get $null))
+                                  (ref.test (ref $Pair) (local.get $elem))))
+                                (then (call $raise-pair-expected (local.get $elem)) (unreachable)))
+                            (local.set $nlists (i32.add (local.get $nlists) (i32.const 1)))
+                            (local.set $outer (struct.get $Pair $d (local.get $pair)))
+                            (br $count)))
+
+               ;; Racket's filter-map requires at least one list argument
+               (if (i32.eq (local.get $nlists) (i32.const 0))
+                   (then (call $raise-arity-mismatch) (unreachable)))
+
+               ;; 3) Allocate arrays for list cursors and call arguments; seed list cursors from xss
+               (local.set $lists (array.new $Args (global.get $null) (local.get $nlists)))
+               (local.set $call  (array.new $Args (global.get $null) (local.get $nlists)))
+
+               (local.set $outer (local.get $xss))
+               (local.set $i (i32.const 0))
+               (block $seed_done
+                      (loop $seed
+                            (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                (then (br $seed_done)))
+                            (local.set $pair (ref.cast (ref $Pair) (local.get $outer)))
+                            (local.set $elem (struct.get $Pair $a (local.get $pair)))
+                            (array.set $Args (local.get $lists) (local.get $i) (local.get $elem))
+                            (local.set $outer (struct.get $Pair $d (local.get $pair)))
+                            (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                            (br $seed)))
+
+               ;; 4) Main loop: stop at the shortest list
+               (local.set $acc (global.get $null))
+
+               (loop $loop
+                     ;; (a) Check state of all lists; determine if we stop
+                     (local.set $stop (i32.const 0))
+                     (local.set $i (i32.const 0))
+                     (block $check_done
+                            (loop $check
+                                  (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                      (then (br $check_done)))
+                                  (local.set $cur (array.get $Args (local.get $lists) (local.get $i)))
+                                  (if (ref.eq (local.get $cur) (global.get $null))
+                                      (then (local.set $stop (i32.const 1)))
+                                      (else
+                                       (if (i32.eqz (ref.test (ref $Pair) (local.get $cur)))
+                                           (then (call $raise-pair-expected (local.get $cur)) (unreachable)))))
+                                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                                  (br $check)))
+
+                     ;; If any list is empty → finish by reversing $acc
+                     (if (i32.ne (local.get $stop) (i32.const 0))
+                         (then
+                          (local.set $res  (global.get $null))
+                          (local.set $cur  (local.get $acc))
+                          (loop $rev
+                                (if (ref.eq (local.get $cur) (global.get $null))
+                                    (then (return (local.get $res))))
+                                (local.set $pair (ref.cast (ref $Pair) (local.get $cur)))
+                                (local.set $res
+                                           (call $cons
+                                                 (struct.get $Pair $a (local.get $pair))
+                                                 (local.get $res)))
+                                (local.set $cur (struct.get $Pair $d (local.get $pair)))
+                                (br $rev))))
+
+                     ;; (b) Build call args for f: cars of each list
+                     (local.set $i (i32.const 0))
+                     (block $cars_done
+                            (loop $cars
+                                  (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                      (then (br $cars_done)))
+                                  (local.set $pair
+                                             (ref.cast (ref $Pair)
+                                                       (array.get $Args (local.get $lists) (local.get $i))))
+                                  (array.set $Args
+                                             (local.get $call) (local.get $i)
+                                             (struct.get $Pair $a (local.get $pair)))
+                                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                                  (br $cars)))
+
+                     ;; (c) Apply f to those cars
+                     (local.set $r
+                                (call_ref $ProcedureInvoker
+                                          (local.get $f)
+                                          (local.get $call)
+                                          (local.get $finv)))
+
+                     ;; (d) cons the result onto the accumulator if non-#f
+                     (if (ref.eq (local.get $r) (global.get $false))
+                         (then (nop))
+                         (else (local.set $acc (call $cons (local.get $r) (local.get $acc)))))
+
+                     ;; (e) Advance each list (cdr)
+                     (local.set $i (i32.const 0))
+                     (block $cdrs_done
+                            (loop $cdrs
+                                  (if (i32.ge_u (local.get $i) (local.get $nlists))
+                                      (then (br $cdrs_done)))
+                                  (local.set $pair
+                                             (ref.cast (ref $Pair)
+                                                       (array.get $Args (local.get $lists) (local.get $i))))
+                                  (array.set $Args
+                                             (local.get $lists) (local.get $i)
+                                             (struct.get $Pair $d (local.get $pair)))
+                                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                                  (br $cdrs)))
+
+                     (br $loop))
+               (unreachable))
+
          ;; Like filter, but keeps elements for which the predicate returns false
          (func $filter-not (type $Prim>=1)
                (param $proc (ref eq))  ;; predicate

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1427,6 +1427,15 @@
               (and (equal? (filter (λ (x) (positive? x)) '(1 -2 3 4 -5)) '(1 3 4))
                    (equal? (filter (λ (x) (positive? x)) '()) '())))
 
+        (list "filter-map"
+              (and (equal? (filter-map (λ (x) (and (negative? x) (abs x)))
+                                       '(1 2 -3 -4 8))
+                              '(3 4))
+                   (equal? (filter-map (λ (x y) (and (< x y) (+ x y)))
+                                       '(1 2 3)
+                                       '(2 1 4))
+                           '(3 7))))
+
         (list "filter-not"
               (and (equal? (filter-not (λ (x) (positive? x)) '(1 -2 3 4 -5)) '(-2 -5))
                    (equal? (filter-not (λ (x) (positive? x)) '()) '())))


### PR DESCRIPTION
## Summary
- add `filter-map` primitive to runtime
- expose `filter-map` through compiler and exports
- cover `filter-map` with tests

## Testing
- `racket -l errortrace -t webracket.rkt -- -r test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf574079288322a03818bfc0a4c9b1