### PR TITLE
Add rest primitive

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -409,7 +409,7 @@
   cons car cdr
   list              ; not first order yet
   list? length list-ref list-tail list-set list-update
-  first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth last last-pair
+  first rest second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth last last-pair
   append ; variadic list primitive
   flatten
   reverse memq

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -350,10 +350,11 @@ bytes->string/utf-8
  list-update
  list-set
  first
+ rest
  second
- third
- fourth
- fifth
+  third
+  fourth
+  fifth
  sixth
  seventh
  eighth

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -10838,6 +10838,15 @@
                          (local.get $xs)
                         (ref.i31 (i32.shl (i32.const ,idx) (i32.const 1))))))
 
+        (func $rest (type $Prim1) (param $xs (ref eq)) (result (ref eq))
+              ;; Type check: non-empty proper list
+              (if (ref.eq (local.get $xs) (global.get $null))
+                  (then (call $raise-argument-error (local.get $xs)) (unreachable)))
+              (if (ref.eq (call $list? (local.get $xs)) (global.get $false))
+                  (then (call $raise-argument-error (local.get $xs)) (unreachable)))
+              ;; Return tail
+              (struct.get $Pair $d (ref.cast (ref $Pair) (local.get $xs))))
+
         ;; last-pair/checked: takes a Pair and returns the last Pair in the chain
         (func $last-pair/checked
               (param $p (ref $Pair))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1366,6 +1366,10 @@
         (list "first"
               (and (equal? (first '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)) 1)
                    (equal? (procedure-arity first) 1)))
+        (list "rest"
+              (and (equal? (rest '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15))
+                           '(2 3 4 5 6 7 8 9 10 11 12 13 14 15))
+                   (equal? (procedure-arity rest) 1)))
         (list "second"
               (and (equal? (second '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)) 2)
                    (equal? (procedure-arity second) 1)))


### PR DESCRIPTION
## Summary
- support `rest` list primitive in the WebAssembly runtime
- expose `rest` in primitive table and Racket bindings
- test `rest` for correct list-tail behavior

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found: raco)*

------
https://chatgpt.com/codex/tasks/task_e_68bf58c1692083228649eb15dc9c567a