### PR TITLE
Fix inclusive-range negative step handling

### DIFF
--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1493,6 +1493,8 @@
         (list "inclusive-range"
               (and (equal? (inclusive-range 10 20)
                            '(10 11 12 13 14 15 16 17 18 19 20))
+                   (equal? (inclusive-range 20 10)
+                           '(20 19 18 17 16 15 14 13 12 11 10))
                    (equal? (inclusive-range 20 10 -1)
                            '(20 19 18 17 16 15 14 13 12 11 10))
                    (equal? (inclusive-range 10 15 1.5)


### PR DESCRIPTION
## Summary
- Support descending ranges by defaulting the step to -1 when start > end
- Allow negative steps by decoding fixnums with signed shifts and reject a zero step
- Test default descending inclusive-range behavior

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0077431b0832296e3a332452017cd