### PR TITLE
Handle omitted step in inclusive-range

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -3165,8 +3165,10 @@
          [(split-common-prefix)        (inline-prim/optional sym ae1 2 3)]
          [(argmax argmin)              (inline-prim/fixed sym ae1 2)]
          [(filter-map)                 (inline-prim/variadic sym ae1 2)]
-         [(inclusive-range)            (inline-prim/optional/default sym ae1 2 3 (Imm 1))]
-         [(inclusive-range-proc)       (inline-prim/optional/default sym ae1 2 3 (Imm 1))]
+         [(inclusive-range)
+          (inline-prim/optional/default sym ae1 2 3 '(global.get $missing))]
+         [(inclusive-range-proc)
+          (inline-prim/optional/default sym ae1 2 3 '(global.get $missing))]
 
          [(remove)                     (inline-prim/optional sym ae1 2 3)]
          [(take-common-prefix)         (inline-prim/optional sym ae1 2 3)]

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -673,5 +673,11 @@ split-common-prefix
   (raise 42))
 
 
-(define (inclusive-range-proc start end [step 1])
-  (inclusive-range start end step))
+(define (inclusive-range-proc start end [step #f])
+  ;; Step defaults to 1 or -1 depending on order of start and end.
+  ;; Uses flonum defaults when either boundary is inexact.
+  (define default-step
+    (if (<= start end)
+        (if (or (inexact? start) (inexact? end)) 1.0 1)
+        (if (or (inexact? start) (inexact? end)) -1.0 -1)))
+  (inclusive-range start end (if step step default-step)))

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -11348,6 +11348,9 @@
               (result       (ref eq))
               (call $inclusive-range (local.get $start) (local.get $end) (local.get $step)))
 
+        ;; Unlike Racket's @racket[inclusive-range], the step defaults to
+        ;; either 1 or -1 based on the ordering of @racket[start] and
+        ;; @racket[end] when omitted.
         (func $inclusive-range (type $Prim3)
               (param $start-raw (ref eq))
               (param $end-raw   (ref eq))


### PR DESCRIPTION
## Summary
- Ensure compiler passes `$missing` when `inclusive-range` step argument is omitted, allowing runtime to infer sign.
- Document custom default-step behavior for `inclusive-range`.
- Mirror default-step behavior in Racket fallback `inclusive-range-proc`.

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*
- `racket test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00c30b1a88322927c727b3542a6a7