### PR TITLE
Fix remove* comparator handling

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -19,19 +19,18 @@
               (local $v         (ref eq))
               (local $args      (ref $Args))
               (local $r         (ref eq))
-              (local $use-proc  i32)
               (local $found     i32)
               (local $modified  i32)
 
               ;; Handle optional comparator
+              ;; Defaults to equal? when not supplied
               (if (ref.eq (local.get $proc) (global.get $missing))
-                  (then (local.set $use-proc (i32.const 0)))
+                  (then (local.set $proc (global.get $prim:equal?)))
                   (else
                    (if (i32.eqz (ref.test (ref $Procedure) (local.get $proc)))
                        (then (call $raise-argument-error:procedure-expected (local.get $proc))
                              (unreachable))
-                       (else))
-                   (local.set $use-proc (i32.const 1))))
+                       (else))))
 
               ;; If v-lst is empty, return lst directly
               (if (ref.eq (local.get $v-lst) (global.get $null))
@@ -69,27 +68,20 @@
                                         (local.set $vlpair (ref.cast (ref $Pair) (local.get $vlcur)))
                                         (local.set $v (struct.get $Pair $a (local.get $vlpair)))
                                         (local.set $vlcur (struct.get $Pair $d (local.get $vlpair)))
-                                        (block $cont
-                                               (if (i32.eqz (local.get $use-proc))
-                                                   (then
-                                                    (if (ref.eq (call $equal? (local.get $v) (local.get $elem))
-                                                                (global.get $false))
-                                                        (then (br $cont))
-                                                        (else (local.set $found (i32.const 1)) (br $search-done))))
-                                                   (else
-                                                    (local.set $r
-                                                               (call_ref $ProcedureInvoker
-                                                                         (ref.cast (ref $Procedure) (local.get $proc))
-                                                                         (block (result (ref $Args))
-                                                                                (local.set $args (array.new $Args (global.get $null) (i32.const 2)))
-                                                                                (array.set $Args (local.get $args) (i32.const 0) (local.get $v))
-                                                                                (array.set $Args (local.get $args) (i32.const 1) (local.get $elem))
-                                                                                (local.get $args))
-                                                                         (struct.get $Procedure $invoke
-                                                                                     (ref.cast (ref $Procedure) (local.get $proc)))))
-                                                    (if (ref.eq (local.get $r) (global.get $false))
-                                                        (then (br $cont))
-                                                        (else (local.set $found (i32.const 1)) (br $search-done)))))))
+                                          (block $cont
+                                                 (local.set $r
+                                                            (call_ref $ProcedureInvoker
+                                                                      (ref.cast (ref $Procedure) (local.get $proc))
+                                                                      (block (result (ref $Args))
+                                                                             (local.set $args (array.new $Args (global.get $null) (i32.const 2)))
+                                                                             (array.set $Args (local.get $args) (i32.const 0) (local.get $v))
+                                                                             (array.set $Args (local.get $args) (i32.const 1) (local.get $elem))
+                                                                             (local.get $args))
+                                                                      (struct.get $Procedure $invoke
+                                                                                  (ref.cast (ref $Procedure) (local.get $proc))))
+                                                 (if (ref.eq (local.get $r) (global.get $false))
+                                                     (then (br $cont))
+                                                     (else (local.set $found (i32.const 1)) (br $search-done)))))
 
                            (if (i32.eqz (local.get $found))
                                (then (local.set $acc (call $cons (local.get $elem) (local.get $acc))))

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -1491,6 +1491,7 @@
 
         (list "remove*"
               (and (equal? (remove* '(1 2) (list 1 2 3 2 4 5 2)) '(3 4 5))
+                   (equal? (remove* '((2)) '((1) (2) (3))) '((1) (3)))
                    (let ([lst (list 1 2 3)])
                      (and (eq? (remove* '(4 5) lst) lst)
                           (equal? (remove* '(4 5) lst) lst)))


### PR DESCRIPTION
## Summary
- make remove* use a procedure comparator and default to `equal?`
- add regression test for nested list removal

## Testing
- `raco test test/test-basics.rkt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c049ea0ff48322b0389ab4017f3a65