### PR TITLE
Add fx* overflow error reporting

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -1198,6 +1198,8 @@
     (add-runtime-string-constant  'arity-error:start         "arity error: ")
     (add-runtime-string-constant  'arity-error:received      "received: ")
     (add-runtime-string-constant  'arity-error:expected      "expected: ")
+    (add-runtime-string-constant  'fx-overflow:middle        ": fixnum overflow with arguments ")
+    (add-runtime-string-constant  'fx-overflow:and           " and ")
 
     ;; Byte Strings    
     (add-runtime-bytes-constant  'empty                     #"")
@@ -9527,7 +9529,32 @@
                  (ref.i31 (i32.mul (i31.get_s (ref.cast i31ref (local.get $x)))
                                    ,(Half `(i31.get_s (ref.cast i31ref (local.get $y)))))))
 
-         (func $raise-fixnum-overflow (unreachable))
+         (func $raise-fx-overflow
+               (param $who (ref eq))
+               (param $x (ref eq))
+               (param $y (ref eq))
+               (local $message (ref $String))
+               (local $who-str (ref $String))
+               (local $x-str (ref $String))
+               (local $y-str (ref $String))
+
+               (local.set $who-str (call $format/display (local.get $who)))
+               (local.set $x-str (call $format/display (local.get $x)))
+               (local.set $y-str (call $format/display (local.get $y)))
+               (local.set $message (call $string-append/2
+                                         (local.get $who-str)
+                                         (global.get $string:fx-overflow:middle)))
+               (local.set $message (call $string-append/2
+                                         (local.get $message)
+                                         (local.get $x-str)))
+               (local.set $message (call $string-append/2
+                                         (local.get $message)
+                                         (global.get $string:fx-overflow:and)))
+               (local.set $message (call $string-append/2
+                                         (local.get $message)
+                                         (local.get $y-str)))
+               (drop (call $js-log (local.get $message)))
+               (unreachable))
          
          (func $fx* (type $Prim2)
                (param $x (ref eq))
@@ -9555,7 +9582,7 @@
                     (i64.lt_s (local.get $pt) (i64.const -1073741824))  ;; -2^30
                     (i64.gt_s (local.get $pt) (i64.const  1073741822))) ;;  2^30-2
                    (then
-                    (call $raise-fixnum-overflow)
+                    (call $raise-fx-overflow (global.get $symbol:fx*) (local.get $x) (local.get $y))
                     (unreachable))
                    (else))
 

--- a/test/test-fixnums.rkt
+++ b/test/test-fixnums.rkt
@@ -1,0 +1,26 @@
+(list
+ (list "fx*"
+       (equal? (fx* 2 3) 6)
+       (equal? (fx* -2 3 4) -24)
+       (equal? (fx* 1) 1)
+       (equal? (fx* 1 2 3 4) 24))
+ (list "fx* overflow"
+       (with-handlers ([exn:fail? (lambda (e)
+                                    (string=? (exn-message e)
+                                              "fx*: fixnum overflow with arguments 1073741824 and 1073741824"))])
+         (fx* (expt 2 30) (expt 2 30))
+         #f))
+ (list "fx* boundaries"
+       (let* ([a (sub1 (expt 2 14))]
+              [b (sub1 (expt 2 15))]
+              [prod (fx* a b)])
+         (and (fixnum? prod)
+              (equal? prod (* a b))))
+       (let* ([a (- (sub1 (expt 2 14)))]
+              [b (sub1 (expt 2 15))]
+              [prod (fx* a b)])
+         (and (fixnum? prod)
+              (equal? prod (* a b)))))
+ (list "fx+ fx-"
+       (and (equal? (fx+ 10 20) 30)
+            (equal? (fx- 10 3) 7))))


### PR DESCRIPTION
### Motivation
- Surface informative error messages when fixnum multiplication (`fx*`) overflows so failures indicate the primitive and operands involved.

### Description
- Register two new runtime string constants: `fx-overflow:middle` and `fx-overflow:and` for composing the overflow message.
- Add a new runtime function `(func $raise-fx-overflow ...)` that formats the primitive name and argument values with `format/display` and `string-append/2`, logs the composed message via `js-log`, and traps with `unreachable`.
- Replace the prior overflow path in `fx*` to call `$raise-fx-overflow` with `(global.get $symbol:fx*)` and the operand values when the tagged product payload is out of the valid fixnum range.

### Testing
- Omitted per project guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ab144fbfc8322a87ee16f659e2965)