### PR TITLE
Add exn:fail:contract:non-fixnum-result support

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -438,6 +438,7 @@
     struct:exn:fail:contract
     struct:exn:fail:contract:arity
     struct:exn:fail:contract:divide-by-zero
+    struct:exn:fail:contract:non-fixnum-result
     struct:exn:fail:contract:variable
     struct:exn:fail:read
     struct:exn:fail:read:eof
@@ -558,6 +559,10 @@
   exn:fail:contract:divide-by-zero
   exn:fail:contract:divide-by-zero?
   make-exn:fail:contract:divide-by-zero
+
+  exn:fail:contract:non-fixnum-result
+  exn:fail:contract:non-fixnum-result?
+  make-exn:fail:contract:non-fixnum-result
   
   exn:fail:contract:variable
   exn:fail:contract:variable?
@@ -1549,6 +1554,7 @@
                          kern-exn:fail:contract kern-exn:fail:contract?
                          kern-exn:fail:contract:arity kern-exn:fail:contract:arity?
                          kern-exn:fail:contract:divide-by-zero kern-exn:fail:contract:divide-by-zero?
+                         kern-exn:fail:contract:non-fixnum-result kern-exn:fail:contract:non-fixnum-result?
                          kern-exn:fail:contract:variable kern-exn:fail:contract:variable?
                          kern-exn:fail:contract:variable-id
                          kern-exn:fail:read kern-exn:fail:read?
@@ -1573,6 +1579,8 @@
     [kern-exn:fail:contract:arity?          #'exn:fail:contract:arity?]
     [kern-exn:fail:contract:divide-by-zero  #'exn:fail:contract:divide-by-zero]
     [kern-exn:fail:contract:divide-by-zero? #'exn:fail:contract:divide-by-zero?]
+    [kern-exn:fail:contract:non-fixnum-result #'exn:fail:contract:non-fixnum-result]
+    [kern-exn:fail:contract:non-fixnum-result? #'exn:fail:contract:non-fixnum-result?]
     [kern-exn:fail:contract:variable        #'exn:fail:contract:variable]
     [kern-exn:fail:contract:variable?       #'exn:fail:contract:variable?]
     [kern-exn:fail:contract:variable-id     #'exn:fail:contract:variable-id]

--- a/priminfo.rkt
+++ b/priminfo.rkt
@@ -106,6 +106,7 @@
     exn:fail:contract
     exn:fail:contract:arity
     exn:fail:contract:divide-by-zero
+    exn:fail:contract:non-fixnum-result
     exn:fail:contract:variable
     exn:fail:read
     exn:fail:read:eof

--- a/primitives.rkt
+++ b/primitives.rkt
@@ -92,6 +92,7 @@
          struct:exn:fail:contract
          struct:exn:fail:contract:arity
          struct:exn:fail:contract:divide-by-zero
+         struct:exn:fail:contract:non-fixnum-result
          struct:exn:fail:contract:variable
          struct:exn:fail:read
          struct:exn:fail:read:eof
@@ -114,6 +115,8 @@
          exn:fail:contract:arity?
          exn:fail:contract:divide-by-zero
          exn:fail:contract:divide-by-zero?
+         exn:fail:contract:non-fixnum-result
+         exn:fail:contract:non-fixnum-result?
          exn:fail:contract:variable
          exn:fail:contract:variable?
          exn:fail:contract:variable-id
@@ -140,6 +143,7 @@
          make-exn:fail:contract
          make-exn:fail:contract:arity
          make-exn:fail:contract:divide-by-zero
+         make-exn:fail:contract:non-fixnum-result
          make-exn:fail:contract:variable
          make-exn:fail:read
          make-exn:fail:read:eof

--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -66,6 +66,7 @@
         (struct:exn:fail:contract                ensure-exn:fail:contract-type)
         (struct:exn:fail:contract:arity          ensure-exn:fail:contract:arity-type)
         (struct:exn:fail:contract:divide-by-zero ensure-exn:fail:contract:divide-by-zero-type)
+        (struct:exn:fail:contract:non-fixnum-result ensure-exn:fail:contract:non-fixnum-result-type)
         (struct:exn:fail:contract:variable       ensure-exn:fail:contract:variable-type)
         (struct:exn:fail:read                    ensure-exn:fail:read-type)
         (struct:exn:fail:read:eof                ensure-exn:fail:read:eof-type)
@@ -1026,6 +1027,9 @@
           exn:fail:contract:divide-by-zero
           exn:fail:contract:divide-by-zero?
           make-exn:fail:contract:divide-by-zero
+          exn:fail:contract:non-fixnum-result
+          exn:fail:contract:non-fixnum-result?
+          make-exn:fail:contract:non-fixnum-result
           exn:fail:contract:variable
           exn:fail:contract:variable?
           make-exn:fail:contract:variable
@@ -2164,6 +2168,7 @@
          (global $exn:fail:contract-type                (mut (ref null $StructType)) (ref.null $StructType))
          (global $exn:fail:contract:arity-type          (mut (ref null $StructType)) (ref.null $StructType))
          (global $exn:fail:contract:divide-by-zero-type (mut (ref null $StructType)) (ref.null $StructType))
+         (global $exn:fail:contract:non-fixnum-result-type (mut (ref null $StructType)) (ref.null $StructType))
          (global $exn:fail:contract:variable-type       (mut (ref null $StructType)) (ref.null $StructType))
 
          (global $exn:fail:read-type                    (mut (ref null $StructType)) (ref.null $StructType))
@@ -4566,6 +4571,37 @@
                     (local.set $existing (local.get $std))))
                (ref.as_non_null (local.get $existing)))
 
+         ;; Kernel exception fail:contract:non-fixnum-result struct type descriptor cache
+         (func $ensure-exn:fail:contract:non-fixnum-result-type
+               (result (ref $StructType))
+
+               (local $existing (ref null $StructType))
+               (local $std      (ref $StructType))
+               (local $super    (ref $StructType))
+               (local $immut    (ref eq))
+
+               (local.set $existing (global.get $exn:fail:contract:non-fixnum-result-type))
+               (if (ref.is_null (local.get $existing))
+                   (then
+                    (local.set $super (call $ensure-exn:fail:contract-type))
+                    (local.set $immut (struct.get $StructType $immutables (local.get $super)))
+                    (local.set $std
+                               (call $make-struct-type-descriptor/checked
+                                     (ref.cast (ref $Symbol) (global.get $symbol:exn:fail:contract:non-fixnum-result))
+                                     (ref.cast (ref eq) (local.get $super))
+                                     (i32.const 0)
+                                     (i32.const 0)
+                                     (global.get $false)
+                                     (global.get $null)
+                                     (global.get $false)
+                                     (global.get $false)
+                                     (local.get $immut)
+                                     (global.get $false)
+                                     (ref.cast (ref $Symbol) (global.get $symbol:exn:fail:contract:non-fixnum-result))))
+                    (global.set $exn:fail:contract:non-fixnum-result-type (local.get $std))
+                    (local.set $existing (local.get $std))))
+               (ref.as_non_null (local.get $existing)))
+
          ;; Kernel exception fail:contract:variable struct type descriptor cache
          (func $ensure-exn:fail:contract:variable-type
                (result (ref $StructType))
@@ -4747,6 +4783,29 @@
                            (local.get $std)
                            (local.get $fields)))
 
+         ;; Construct a kernel exception:fail:contract:non-fixnum-result instance
+         (func $exn:fail:contract:non-fixnum-result/make
+               (param $message (ref eq)) ; string
+               (param $marks   (ref eq)) ; continuation-mark-set?
+               (result (ref $Struct))
+
+               (local $std    (ref $StructType))
+               (local $fields (ref $Array))
+
+               (local.set $std (call $ensure-exn:fail:contract:non-fixnum-result-type))
+               (local.set $fields
+                          (array.new_fixed $Array 2
+                                           (local.get $message)
+                                           (local.get $marks)))
+               (struct.new $Struct
+                           (i32.const 0)
+                           (global.get $false)
+                           (ref.i31 (i32.const 0))
+                           (global.get $false)
+                           (ref.func $invoke-struct)
+                           (local.get $std)
+                           (local.get $fields)))
+
          ;; Construct a kernel exception:fail:contract:variable instance
          (func $exn:fail:contract:variable/make
                (param $message (ref eq)) ; string
@@ -4894,6 +4953,51 @@
                (local $ok     i32)
 
                (local.set $std (call $ensure-exn:fail:contract:divide-by-zero-type))
+               (if (result (ref eq))
+                   (ref.test (ref $Struct) (local.get $v))
+                   (then
+                    (local.set $struct (ref.cast (ref $Struct) (local.get $v)))
+                    (local.set $ok (call $struct-type-is-a?/i32
+                                             (struct.get $Struct $type (local.get $struct))
+                                             (local.get $std)))
+                    (if (result (ref eq))
+                        (local.get $ok)
+                        (then (global.get $true))
+                        (else (global.get $false))))
+                   (else (global.get $false))))
+
+         ;; exn:fail:contract:non-fixnum-result : string? continuation-mark-set? -> exn:fail:contract:non-fixnum-result
+         (func $exn:fail:contract:non-fixnum-result (type $Prim2)
+               (param $message (ref eq)) ; string
+               (param $marks   (ref eq)) ; continuation-mark-set?
+               (result (ref eq))
+
+               (ref.cast (ref eq)
+                         (call $exn:fail:contract:non-fixnum-result/make
+                               (call $exn-ensure-message (global.get $symbol:exn:fail:contract:non-fixnum-result) (local.get $message))
+                               (local.get $marks))))
+
+         ;; make-exn:fail:contract:non-fixnum-result : string? continuation-mark-set? -> exn:fail:contract:non-fixnum-result
+         (func $make-exn:fail:contract:non-fixnum-result (type $Prim2)
+               (param $message (ref eq)) ; string
+               (param $marks   (ref eq)) ; continuation-mark-set?
+               (result (ref eq))
+
+               (ref.cast (ref eq)
+                         (call $exn:fail:contract:non-fixnum-result/make
+                               (call $exn-ensure-message (global.get $symbol:make-exn:fail:contract:non-fixnum-result) (local.get $message))
+                               (local.get $marks))))
+
+         ;; exn:fail:contract:non-fixnum-result? : any/c -> boolean?
+         (func $exn:fail:contract:non-fixnum-result? (type $Prim1)
+               (param $v (ref eq)) ; any/c
+               (result (ref eq))
+
+               (local $std    (ref $StructType))
+               (local $struct (ref $Struct))
+               (local $ok     i32)
+
+               (local.set $std (call $ensure-exn:fail:contract:non-fixnum-result-type))
                (if (result (ref eq))
                    (ref.test (ref $Struct) (local.get $v))
                    (then

--- a/test/completion.rkt
+++ b/test/completion.rkt
@@ -1572,6 +1572,7 @@
          struct:exn:fail:contract
          struct:exn:fail:contract:arity
          struct:exn:fail:contract:divide-by-zero
+         struct:exn:fail:contract:non-fixnum-result
          struct:exn:fail:contract:variable
          struct:exn:fail:read
          struct:exn:fail:read:eof

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -3910,22 +3910,28 @@
                      [arity-make    (make-exn:fail:contract:arity "made-arity" marks)]
                      [divide        (exn:fail:contract:divide-by-zero "divide" marks)]
                      [divide-make   (make-exn:fail:contract:divide-by-zero "made-divide" marks)]
+                     [non-fixnum    (exn:fail:contract:non-fixnum-result "non-fixnum" marks)]
+                     [non-fixnum-make (make-exn:fail:contract:non-fixnum-result "made-non-fixnum" marks)]
                      [variable      (exn:fail:contract:variable "variable" marks 'id)]
                      [variable-make (make-exn:fail:contract:variable "made-variable" marks 'made-id)])
                 (and (equal? (exn:fail? contract) #t)
                      (equal? (exn:fail:contract? contract) #t)
                      (equal? (exn:fail:contract? arity) #t)
                      (equal? (exn:fail:contract? divide) #t)
+                     (equal? (exn:fail:contract? non-fixnum) #t)
                      (equal? (exn:fail:contract? variable) #t)
                      (equal? (exn:fail:contract? contract-make) #t)
                      (equal? (exn:fail:contract? arity-make) #t)
                      (equal? (exn:fail:contract? divide-make) #t)
+                     (equal? (exn:fail:contract? non-fixnum-make) #t)
                      (equal? (exn:fail:contract? variable-make) #t)
                      (equal? (exn:fail:contract:arity? contract) #f)
                      (equal? (exn:fail:contract:arity? arity) #t)
                      (equal? (exn:fail:contract:arity? arity-make) #t)
                      (equal? (exn:fail:contract:divide-by-zero? divide) #t)
                      (equal? (exn:fail:contract:divide-by-zero? divide-make) #t)
+                     (equal? (exn:fail:contract:non-fixnum-result? non-fixnum) #t)
+                     (equal? (exn:fail:contract:non-fixnum-result? non-fixnum-make) #t)
                      (equal? (exn:fail:contract:variable? variable) #t)
                      (equal? (exn:fail:contract:variable? variable-make) #t)
                      (equal? (exn:fail:contract:variable-id variable) 'id)
@@ -3933,6 +3939,7 @@
                      (equal? (exn-message contract) "contract")
                      (equal? (exn-message arity) "arity")
                      (equal? (exn-message divide) "divide")
+                     (equal? (exn-message non-fixnum) "non-fixnum")
                      (equal? (exn-message variable) "variable"))))
 
         (list "exn:fail:read structures"
@@ -4320,4 +4327,3 @@
          )
 
  )
-


### PR DESCRIPTION
### Motivation
- Add support for the `exn:fail:contract:non-fixnum-result` exception kind so the runtime can construct, identify, and expose this contract-failure variant consistent with Racket.

### Description
- Implemented the struct type descriptor, constructor, maker, and predicate for `exn:fail:contract:non-fixnum-result` in `runtime-wasm.rkt` and wired it into the runtime symbol/primitive tables.
- Exposed the new struct and primitives in `primitives.rkt` and updated compiler metadata and kernel-renaming mappings in `compiler.rkt` and `priminfo.rkt`.
- Added coverage for the new exception variant to test lists and completion constants in `test/test-basics.rkt` and `test/completion.rkt`.

### Testing
- N/A.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad4a8f8e08322857f6aebae79a22f)