### PR TITLE
Fix expt fixnum range handling

### DIFF
--- a/runtime-wasm.rkt
+++ b/runtime-wasm.rkt
@@ -7568,11 +7568,11 @@
                   (then
                        (if (f64.eq (f64.floor (local.get $res)) (local.get $res))
                        (then
-                        ;; 1073741823.0 = 2^30-1 and -1073741824.0 = -2^30
+                        ;; 536870911.0 = 2^29-1 and -536870912.0 = -2^29
                         ;; ensure result fits in fixnum range before converting
-                        (if (f64.le (local.get $res) (f64.const 1073741823.0))
+                        (if (f64.le (local.get $res) (f64.const 536870911.0))
                             (then
-                             (if (f64.ge (local.get $res) (f64.const -1073741824.0))
+                             (if (f64.ge (local.get $res) (f64.const -536870912.0))
                                  (then
                                   (return (ref.i31 (i32.shl (i32.trunc_f64_s (local.get $res)) (i32.const 1))))))))))))
 

--- a/test/test-basics.rkt
+++ b/test/test-basics.rkt
@@ -541,7 +541,8 @@
                                  (and (= s 3.0) (= r 6.0)))))
                     (list "expt"
                           (and (equal? (expt 2 5) 32)
-                               (equal? (expt 9.0 0.5) 3.0)))
+                               (equal? (expt 9.0 0.5) 3.0)
+                               (= (- (expt 2 29)) -536870912)))
                     (list "exp"
                           (and (equal? (exp 0) 1)
                                (< (abs (- (exp 1.0) 2.718281828459045)) 1e-12)))


### PR DESCRIPTION
### Motivation
- Fix an incorrect bound check in the `expt` runtime that produced invalid tagged `i31` values (leading to a `RuntimeError: unreachable`) for large exact power results.

### Description
- Change the fixnum-fit check in `expt` in `runtime-wasm.rkt` to use the signed fixnum limits `2^29-1` and `-2^29` when converting an exact integral `expt` result into a tagged fixnum, and add a small regression assertion to `test/test-basics.rkt` validating `(- (expt 2 29))`.

### Testing
- n/a

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b99be1c808322b767361df5024672)