### PR TITLE
Format hash comparison functions as code on website

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -277,7 +277,15 @@ CSS
                (list `(h3 "Numbers")
                      `(p "Flonums and fixnums."))
                (list `(h3 "Hash Tables")
-                     `(p "Mutable hash tables for eq?, eqv?, equal?, and always? comparisons."))
+                     `(p "Mutable hash tables for "
+                         (code "eq?")
+                         ", "
+                         (code "eqv?")
+                         ", "
+                         (code "equal?")
+                         ", and "
+                         (code "always?")
+                         " comparisons."))
                (list `(h3 "Structures")
                      `(p "Support for structure properties, super structures, and applicable structs."))
                (list `(h3 "Syntax")


### PR DESCRIPTION
### Motivation
- Improve readability of the Language Coverage card by rendering Racket predicate names in a typewriter/code style so they stand out as function names.

### Description
- Update `web-site/src/web-site.rkt` to wrap the hash comparison function names with `(code ...)` so `eq?`, `eqv?`, `equal?`, and `always?` are rendered in inline code on the Language Coverage card.

### Testing
- Attempted to build the site with `racket ../../webracket.rkt --browser --ffi dom --stdlib web-site.rkt`, but `racket` was not available in the environment so no automated site build or tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739a8a68748322bce333c0b06a52c3)