### PR TITLE
Bold hash comparison function names on website

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -278,13 +278,13 @@ CSS
                      `(p "Flonums and fixnums."))
                (list `(h3 "Hash Tables")
                      `(p "Mutable hash tables for "
-                         (code "eq?")
+                         (strong (code "eq?"))
                          ", "
-                         (code "eqv?")
+                         (strong (code "eqv?"))
                          ", "
-                         (code "equal?")
+                         (strong (code "equal?"))
                          ", and "
-                         (code "always?")
+                         (strong (code "always?"))
                          " comparisons."))
                (list `(h3 "Structures")
                      `(p "Support for structure properties, super structures, and applicable structs."))


### PR DESCRIPTION
### Motivation
- Improve emphasis and readability of hash comparison function names in the Language Coverage card on the WebRacket website.

### Description
- Wrap **`eq?`**, **`eqv?`**, **`equal?`**, and **`always?`** in bold monospace by replacing `(code "...")` with `(strong (code "..."))` in `web-site/src/web-site.rkt`.

### Testing
- No automated tests were added or modified for this cosmetic documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739b7d95d083228aaea05f61a0bcf7)