### PR TITLE
Move hero carousel into its own panel and add screenshot margins

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -153,12 +153,6 @@ a { color: var(--blue); text-decoration: none; }
   padding: 36px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 }
-.hero-content {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 24px;
-  align-items: center;
-}
 .hero-copy {
   flex: 1 1 260px;
   min-width: 220px;
@@ -176,8 +170,14 @@ a { color: var(--blue); text-decoration: none; }
   display: flex;
   flex-direction: column;
   gap: 12px;
-  flex: 0 0 auto;
   width: min(260px, 45vw);
+}
+.hero-carousel-panel {
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 20px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 }
 .carousel-header {
   display: flex;
@@ -194,16 +194,18 @@ a { color: var(--blue); text-decoration: none; }
   box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
   aspect-ratio: 4 / 3;
   background: var(--surface);
+  padding: 12px;
 }
 .carousel-shot {
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  inset: 12px;
+  width: calc(100% - 24px);
+  height: calc(100% - 24px);
   object-fit: cover;
   opacity: 0;
   transform: scale(1.02);
   animation: carouselFade 30s infinite;
+  border-radius: 10px;
 }
 @keyframes carouselFade {
   0% { opacity: 0; transform: scale(1.02); }
@@ -304,42 +306,42 @@ CSS
           (section (@ (class "hero"))
                    (div (@ (class "hero-panel"))
                         (h1 (@ (class "hero-title")) "WebRacket")
-                        (div (@ (class "hero-content"))
-                             (div (@ (class "hero-copy"))
-                                  (p  (@ (class "hero-lead"))
-                                      "A Racket to WebAssembly compiler. Build practical browser applications with Racket.")
-                                  (div (@ (class "pill-row"))
-                                       (span (@ (class "pill")) "JS + DOM FFI")
-                                       (span (@ (class "pill")) "Runs in browsers + Node")))
-                             (div (@ (class "hero-carousel"))
-                                  (div (@ (class "carousel-header"))
-                                       (span "Example screenshots")
-                                       (span (@ (class "highlight")) "Live demos"))
-                                  (div (@ (class "carousel-frame"))
-                                       (img (@ (class "carousel-shot")
-                                               (src   "assets/examples/screenshots/mathjax4.png")
-                                               (alt   "MathJax 4 editor")
-                                               (style "animation-delay: 0s;")))
-                                       (img (@ (class "carousel-shot")
-                                               (src   "assets/examples/screenshots/matrix-rain.png")
-                                               (alt   "Matrix digital rain demo")
-                                               (style "animation-delay: 5s;")))
-                                       (img (@ (class "carousel-shot")
-                                               (src   "assets/examples/screenshots/xtermjs.png")
-                                               (alt   "XtermJS terminal demo")
-                                               (style "animation-delay: 10s;")))
-                                       (img (@ (class "carousel-shot")
-                                               (src   "assets/examples/screenshots/minischeme.png")
-                                               (alt   "MiniScheme browser REPL")
-                                               (style "animation-delay: 15s;")))
-                                       (img (@ (class "carousel-shot")
-                                               (src   "assets/examples/screenshots/space-invaders.png")
-                                               (alt   "Space Invaders canvas game")
-                                               (style "animation-delay: 20s;")))
-                                       (img (@ (class "carousel-shot")
-                                               (src   "assets/examples/screenshots/pict.png")
-                                               (alt   "Pict rendering demo")
-                                               (style "animation-delay: 25s;"))))))))
+                        (div (@ (class "hero-copy"))
+                             (p  (@ (class "hero-lead"))
+                                 "A Racket to WebAssembly compiler. Build practical browser applications with Racket.")
+                             (div (@ (class "pill-row"))
+                                  (span (@ (class "pill")) "JS + DOM FFI")
+                                  (span (@ (class "pill")) "Runs in browsers + Node"))))
+                   (div (@ (class "hero-carousel-panel"))
+                        (div (@ (class "hero-carousel"))
+                             (div (@ (class "carousel-header"))
+                                  (span "Example screenshots")
+                                  (span (@ (class "highlight")) "Live demos"))
+                             (div (@ (class "carousel-frame"))
+                                  (img (@ (class "carousel-shot")
+                                          (src   "assets/examples/screenshots/mathjax4.png")
+                                          (alt   "MathJax 4 editor")
+                                          (style "animation-delay: 0s;")))
+                                  (img (@ (class "carousel-shot")
+                                          (src   "assets/examples/screenshots/matrix-rain.png")
+                                          (alt   "Matrix digital rain demo")
+                                          (style "animation-delay: 5s;")))
+                                  (img (@ (class "carousel-shot")
+                                          (src   "assets/examples/screenshots/xtermjs.png")
+                                          (alt   "XtermJS terminal demo")
+                                          (style "animation-delay: 10s;")))
+                                  (img (@ (class "carousel-shot")
+                                          (src   "assets/examples/screenshots/minischeme.png")
+                                          (alt   "MiniScheme browser REPL")
+                                          (style "animation-delay: 15s;")))
+                                  (img (@ (class "carousel-shot")
+                                          (src   "assets/examples/screenshots/space-invaders.png")
+                                          (alt   "Space Invaders canvas game")
+                                          (style "animation-delay: 20s;")))
+                                  (img (@ (class "carousel-shot")
+                                          (src   "assets/examples/screenshots/pict.png")
+                                          (alt   "Pict rendering demo")
+                                          (style "animation-delay: 25s;"))))))))
           ,(section-block
             "Why WebRacket?"
             "WebRacket is a subset of Racket that compiles to WebAssembly, so you can target modern browsers while staying in a familiar language."


### PR DESCRIPTION
### Motivation
- Separate the visual carousel from the hero copy so the screenshots sit in a dedicated panel to the right of the lead content for clearer layout. 
- Add consistent margins and rounded corners to screenshots so they don't abut the carousel frame and read better on varied viewports.

### Description
- Split the hero area by removing the single `.hero-content` wrapper and making the hero copy and the carousel sibling elements (`.hero-copy` and `.hero-carousel-panel`).
- Added `.hero-carousel-panel` CSS with background, border, padding, border-radius, and shadow to create a distinct panel for the carousel.
- Added padding to `.carousel-frame` and adjusted `.carousel-shot` to use `inset` plus `width`/`height` calc values and `border-radius` so screenshots have internal margins and rounded corners.
- Removed an unused flex shorthand on `.hero-carousel` and simplified layout to rely on the grid columns defined on `.hero`.

### Testing
- Attempted to build the site with `racket ../../webracket.rkt --browser --ffi dom --stdlib web-site.rkt`, but `racket` was not available in the environment so the site build / visual verification could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b47861e48322b0724fb43c56e22c)