### PR TITLE
Adjust hero carousel layout

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -144,7 +144,7 @@ a { color: var(--blue); text-decoration: none; }
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 32px;
-  align-items: center;
+  align-items: stretch;
 }
 .hero-panel {
   background: linear-gradient(140deg, rgba(101, 79, 240, 0.2), rgba(74, 108, 255, 0.08));
@@ -152,6 +152,10 @@ a { color: var(--blue); text-decoration: none; }
   border-radius: 28px;
   padding: 36px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  height: 100%;
 }
 .hero-copy {
   flex: 1 1 260px;
@@ -170,7 +174,8 @@ a { color: var(--blue); text-decoration: none; }
   display: flex;
   flex-direction: column;
   gap: 12px;
-  width: min(260px, 45vw);
+  width: min(240px, 100%);
+  flex: 1;
 }
 .hero-carousel-panel {
   background: var(--surface);
@@ -178,6 +183,9 @@ a { color: var(--blue); text-decoration: none; }
   border-radius: 24px;
   padding: 20px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 .carousel-header {
   display: flex;
@@ -201,7 +209,7 @@ a { color: var(--blue); text-decoration: none; }
   inset: 12px;
   width: calc(100% - 24px);
   height: calc(100% - 24px);
-  object-fit: cover;
+  object-fit: contain;
   opacity: 0;
   transform: scale(1.02);
   animation: carouselFade 30s infinite;


### PR DESCRIPTION
### Motivation
- Make the hero area visually balanced by constraining the carousel width, ensuring both hero panels match height, and preventing screenshot cropping.

### Description
- Update `web-site/src/web-site.rkt` CSS so `.hero` uses `align-items: stretch`, make `.hero-panel` and `.hero-carousel-panel` flex containers with `height: 100%`, change `.hero-carousel` to `width: min(240px, 100%)` and `flex: 1`, and set `.carousel-shot` to `object-fit: contain` to show full screenshots.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b69ff15483228cf95c4eb3ea6d8b)