### PR TITLE
Adjust hero sizing and carousel images

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -155,7 +155,6 @@ a { color: var(--blue); text-decoration: none; }
   display: flex;
   flex-direction: column;
   gap: 18px;
-  height: 100%;
 }
 .hero-copy {
   flex: 1 1 260px;
@@ -174,7 +173,6 @@ a { color: var(--blue); text-decoration: none; }
   display: flex;
   flex-direction: column;
   gap: 12px;
-  flex: 1;
 }
 .hero-carousel-panel {
   background: var(--surface);
@@ -184,7 +182,6 @@ a { color: var(--blue); text-decoration: none; }
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 .carousel-header {
   display: flex;
@@ -207,7 +204,7 @@ a { color: var(--blue); text-decoration: none; }
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   opacity: 0;
   transform: scale(1.02);
   animation: carouselFade 30s infinite;


### PR DESCRIPTION
### Motivation
- Reduce excess blank space in the hero panels and avoid cropping of example screenshots so the hero can size to its content while images show fully.

### Description
- Removed forced full-height/flex sizing (`height: 100%`, `flex: 1`) from the hero panels and updated carousel images to use `object-fit: contain` so screenshots are displayed in full (`web-site/src/web-site.rkt`).

### Testing
- Executed `bash web-site/src/build.sh` to exercise the build but it failed because `racket` is not available in the environment, so no site build artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69740fadd6d08322aa7b730fc8200f50)