### PR TITLE
Tighten hero layout spacing and remove carousel border

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -144,7 +144,7 @@ a { color: var(--blue); text-decoration: none; }
   display: grid;
   grid-template-columns: 2fr 1fr;
   gap: 32px;
-  align-items: stretch;
+  align-items: start;
 }
 .hero-panel {
   background: linear-gradient(140deg, rgba(101, 79, 240, 0.2), rgba(74, 108, 255, 0.08));
@@ -194,7 +194,6 @@ a { color: var(--blue); text-decoration: none; }
   position: relative;
   border-radius: 16px;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
   aspect-ratio: 4 / 3;
   background: var(--surface);


### PR DESCRIPTION
### Motivation
- Reduce the large vertical gap under the hero lead and carousel and remove the screenshot outline to make the hero area more compact and visually cleaner.

### Description
- Change `.hero` layout to use `align-items: start` instead of `stretch` so panels do not expand vertically (`web-site/src/web-site.rkt`).
- Remove the `border: 1px solid rgba(255, 255, 255, 0.1);` from `.carousel-frame` to eliminate the outline around screenshots (`web-site/src/web-site.rkt`).

### Testing
- Ran `bash web-site/src/build.sh` locally; the build attempted to run but failed because `racket` is not present in the environment, so no site artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974115c998c83228d2e16b755ec9c69)