### PR TITLE
Remove compiler pipeline connector line

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -507,14 +507,7 @@ a { color: var(--blue); text-decoration: none; }
 }
 @media (min-width: 1000px) {
   .pipeline-grid::after {
-    content: "";
-    position: absolute;
-    top: 28px;
-    left: 24px;
-    right: 24px;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.18), transparent);
-    opacity: 0.7;
+    content: none;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Remove the decorative horizontal “pipeline connector” line from the Compiler Pipeline section to achieve a cleaner, less decorative landing page while keeping numbered badges and cards unchanged.

### Description
- Replace the `.pipeline-grid::after` pseudo-element content with `content: none;` in `web-site/src/web-site.rkt`, removing the absolute-positioned gradient line with a minimal CSS change and no layout or badge modifications.

### Testing
- Testing information omitted per project PR guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ee186f588322865e60fc2a850b72)