### PR TITLE
Adjust hero spacing between lead, pills, and CTAs

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -173,7 +173,8 @@ a { color: var(--blue); text-decoration: none; }
   margin: 0 0 12px;
 }
 .hero-lead {
-  margin: 0 0 18px;
+  /* Hero spacing polish */
+  margin: 0 0 22px;
   color: var(--muted);
   line-height: 1.6;
 }
@@ -227,6 +228,8 @@ a { color: var(--blue); text-decoration: none; }
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+  /* Hero spacing polish */
+  margin-bottom: 8px;
 }
 .pill {
   border-radius: 999px;
@@ -555,7 +558,8 @@ a { color: var(--blue); text-decoration: none; }
   flex-wrap: wrap;
   gap: 14px;
   align-items: center;
-  margin-top: 6px;
+  /* Hero spacing polish */
+  margin-top: 12px;
 }
 .cta-button {
   display: inline-flex;


### PR DESCRIPTION
### Motivation
- Provide a subtle increase in vertical breathing room between the lead/subtitle, the pill row, and the CTA row to improve perceived spacing without altering layout, fonts, or overall hero height.

### Description
- Increase `.hero-lead` bottom margin from `18px` to `22px` and add a `/* Hero spacing polish */` comment.
- Add `margin-bottom: 8px` to `.pill-row` with a `/* Hero spacing polish */` comment to separate pills from the CTAs.
- Increase `.hero-cta` top margin from `6px` to `12px` and add a `/* Hero spacing polish */` comment.

### Testing
- Per repository PR guidelines, testing details are omitted from this PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697565505890832287fbf1d23b4a5884)