### PR TITLE
Refine examples page featured styling and next steps cues

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -99,7 +99,7 @@
                     (cons 'path "examples/matrix-rain")
                     (cons 'entry "matrix-rain.html")
                     (cons 'tags (list 'xterm 'dom))
-                    (cons 'summary "Matrix rain animation rendered in a browser terminal.")
+                    (cons 'summary "Matrix-style digital rain rendered in a browser terminal.")
                     (cons 'features (list "XtermJS integration"
                                           "DOM + JS FFI"
                                           "Timers / animation loop"))))
@@ -117,7 +117,7 @@
                     (cons 'path "examples/minischeme")
                     (cons 'entry "minischeme.html")
                     (cons 'tags (list 'repl 'xterm))
-                    (cons 'summary "Browser-based Scheme REPL with evaluator, editor, and output.")
+                    (cons 'summary "Browser-based Scheme REPL with editor, evaluator, and output.")
                     (cons 'features (list "XtermJS terminal"
                                           "Input handling + history"
                                           "Runtime evaluator"
@@ -460,34 +460,36 @@
         ,@(if (null? featured-examples)
               '()
               (list
-               (section-block
-                "Featured"
-                "Start here for the most representative WebRacket demos."
-                (list (examples-grid featured-examples "examples-grid--featured"))
-                #f
-                "section--examples section-featured")))
+               `(section (@ (class "section-featured"))
+                         ,(section-block
+                           "Featured"
+                           "Start here for the most representative WebRacket demos."
+                           (list (examples-grid featured-examples "examples-grid--featured"))
+                           #f
+                           "section--examples"))))
         ,(section-block
           "All examples"
           "Browse every example in the repository."
           (list (examples-grid all-examples))
           #f
           "section--examples")
-        ,(section-block
-          "Next steps"
-          "Ready to build your own? Here are a few good places to continue."
-          (list
-           `(ul (@ (class "next-steps-links"))
-                (li (a (@ (class "example-action action-primary")
-                          (href "installation.html"))
-                       "Installation"))
-                (li (a (@ (class "example-action action-secondary")
-                          (href "overview.html"))
-                       "Overview"))
-                (li (a (@ (class "example-action action-secondary")
-                          (href "roadmap.html"))
-                       "Road Ahead"))))
-          #f
-          "section--examples section-next-steps")
+        (section (@ (class "next-steps-panel"))
+                 ,(section-block
+                   "Next steps"
+                   "Ready to build your own? Here are a few good places to continue."
+                   (list
+                    `(ul (@ (class "next-steps-links"))
+                         (li (a (@ (class "example-action action-primary")
+                                   (href "installation.html"))
+                                "Installation →"))
+                         (li (a (@ (class "example-action action-secondary")
+                                   (href "overview.html"))
+                                "Overview →"))
+                         (li (a (@ (class "example-action action-secondary")
+                                   (href "roadmap.html"))
+                                "Road Ahead →"))))
+                   #f
+                   "section--examples section-next-steps"))
         ,(footer-section)))
 
 ;; installation-page : -> List
@@ -1305,10 +1307,11 @@ pre code {
   outline-offset: 3px;
 }
 
-/* Examples emphasis */
-/* Examples: featured accent line */
+/* Featured accent */
 .section-featured .section-title::after {
-  width: 72px;
+  height: 3px;
+  opacity: 0.95;
+  width: 84px;
 }
 .sr-only {
   position: absolute;
@@ -1340,7 +1343,7 @@ pre code {
   position: relative;
   overflow: hidden;
 }
-/* Examples: category cue strip */
+/* Example category strip */
 .example-card::before {
   content: "";
   position: absolute;
@@ -1348,14 +1351,23 @@ pre code {
   left: 0;
   right: 0;
   height: 2px;
-  background: var(--example-accent, rgba(101, 79, 240, 0.22));
+  opacity: 0.25;
   pointer-events: none;
 }
-.example-card.kind-dom { --example-accent: rgba(82, 110, 255, 0.22); }
-.example-card.kind-canvas { --example-accent: rgba(86, 138, 255, 0.22); }
-.example-card.kind-repl { --example-accent: rgba(132, 96, 255, 0.24); }
-.example-card.kind-mathjax { --example-accent: rgba(146, 112, 255, 0.24); }
-.example-card.kind-xterm { --example-accent: rgba(88, 92, 255, 0.24); }
+.kind-dom::before { background: #6A7CFF; }
+.kind-canvas::before { background: #5FB6FF; }
+.kind-mathjax::before { background: #8B6CFF; }
+.kind-xterm::before { background: #5662D9; }
+.kind-repl::before { background: #7A5CFF; }
+/* Featured card emphasis */
+.section-featured .example-card {
+  padding: calc(var(--card-padding) + 8px);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+.section-featured .example-card h3 {
+  font-size: 1.06em;
+}
 .example-showcases {
   display: flex;
   flex-direction: column;
@@ -1389,6 +1401,14 @@ pre code {
 }
 .next-steps-links li {
   margin: 0;
+}
+/* Next steps CTA */
+.next-steps-panel {
+  background: rgba(120, 100, 255, 0.12);
+  border-left: 2px solid rgba(140, 120, 255, 0.8);
+}
+.next-steps-panel a:hover {
+  text-decoration: underline;
 }
 .example-action {
   color: var(--text);


### PR DESCRIPTION
### Motivation
- Strengthen the visual emphasis for the Featured examples and Next Steps panel to match the requested design tweaks. 
- Add subtle category cues on example cards to surface example types without changing layout or content. 
- Apply two exact copy fixes for example summaries.

### Description
- Updated example data copy: changed Matrix Rain summary to "Matrix-style digital rain rendered in a browser terminal." and MiniScheme summary to "Browser-based Scheme REPL with editor, evaluator, and output." in `web-site/src/web-site.rkt`.
- Wrapped the Featured block in a `<section class="section-featured">` wrapper so the accent rule targets only that section, and adjusted the Examples page structure to use a `section` with the new wrapper.
- Replaced the Next Steps section wrapper with `<section class="next-steps-panel">` and appended arrows to the CTA labels: "Installation →", "Overview →", and "Road Ahead →".
- Added/updated CSS rules in the page stylesheet (grouped under the requested comments):
  - /* Featured accent */: `.section-featured .section-title::after` sets `height: 3px`, `opacity: 0.95`, and `width: 84px`.
  - /* Example category strip */: `.example-card::before` provides a 2px top strip with `opacity: 0.25`, and new `.kind-dom`, `.kind-canvas`, `.kind-mathjax`, `.kind-xterm`, `.kind-repl` `::before` background hue rules are added (non-glowing solid colors).
  - /* Featured card emphasis */: `.section-featured .example-card` increases padding, raises border opacity, and strengthens shadow; and `.section-featured .example-card h3` increases title size by ~2px (`1.06em`).
  - /* Next steps CTA */: `.next-steps-panel` sets a brighter background and a 2px purple-indigo left accent bar, and `.next-steps-panel a:hover` enables underline on hover.

### Testing
- Attempted to run the site build via `./build.sh`, but `racket` is not available in the environment so the build could not complete (observed `racket: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b0bc3e408322b20ca36a006cb198)