### PR TITLE
Link navbar branding to home page

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -249,10 +249,11 @@
   (define active-page (current-page))
   `(nav (@ (class "navbar"))
         (div (@ (class "nav-left"))
-             (img (@ (class "nav-logo")
-                     (src "assets/hex-racket-wasm-logo.svg")
-                     (alt "WebRacket logo")))
-             (span "WebRacket"))
+             (a (@ (class "nav-home") (href "index.html"))
+                (img (@ (class "nav-logo")
+                        (src "assets/hex-racket-wasm-logo.svg")
+                        (alt "WebRacket logo")))
+                (span "WebRacket")))
         (div (@ (class "nav-links"))
              ,(nav-link "For You" "is-webracket-for-you.html" 'for-you active-page)
              ,(nav-link "Overview" "overview.html" 'overview active-page)
@@ -646,6 +647,22 @@ a { color: var(--blue); text-decoration: none; }
   gap: 12px;
   font-weight: 600;
   font-size: 1.05rem;
+}
+.nav-home {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text);
+}
+.nav-home:hover,
+.nav-home:focus-visible {
+  opacity: 0.9;
+}
+.nav-home:focus-visible {
+  outline: 2px solid rgba(74, 108, 255, 0.6);
+  outline-offset: 4px;
+  border-radius: 999px;
+  padding-right: 4px;
 }
 .nav-logo {
   width: 34px;


### PR DESCRIPTION
### Motivation
- Ensure the site branding in the upper-left (logo + “WebRacket” text) is a clickable link that navigates users to the main page from any sub-page for improved discoverability and UX.

### Description
- Wrap the logo and title in an anchor linking to `index.html` in `web-site/src/web-site.rkt` and add a `nav-home` class for the new element.
- Add minimal CSS rules for `.nav-home` to provide hover and focus-visible styling and keyboard focus outlines within the same file.

### Testing
- No automated tests were run for this small markup/CSS update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69780b176ab0832294eb3345875f5fad)