### PR TITLE
Align examples cards with shared styling

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1341,17 +1341,6 @@ pre code {
 .examples-grid {
   gap: 20px;
 }
-.examples-grid .card {
-  background: linear-gradient(145deg, rgba(20, 22, 43, 0.95), rgba(20, 22, 43, 0.7));
-  border-color: hsla(var(--accent-h), 75%, 78%, 0.12);
-}
-.examples-grid--featured .card {
-  padding: 24px;
-  border-color: hsla(var(--accent-h), 78%, 82%, 0.18);
-}
-.examples-grid--featured .card:nth-child(even) {
-  padding-top: 26px;
-}
 .example-card {
   gap: 16px;
   position: relative;


### PR DESCRIPTION
### Motivation
- Ensure the Examples pages use the same card appearance as other pages by removing page-specific card overrides so cards inherit the shared `.card` styling.

### Description
- Deleted the `.examples-grid .card` and `.examples-grid--featured .card` CSS overrides from `web-site/src/web-site.rkt` so example cards fall back to the global `.card` rules.

### Testing
- Attempted to run the site build with `./build.sh`, but the local `racket` toolchain is not available so no automated build or tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69781868f7708322975725b982a36b39)