### PR TITLE
Fix completion status page paren mismatch

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -2877,4 +2877,4 @@
                  ,@(map chapter-block prepared-chapters)))
           #f
           "section--status")
-        ,(footer-section)))
+        ,(footer-section))


### PR DESCRIPTION
### Motivation
- Fix a read error raised while including `completion.rkt` caused by an extra closing parenthesis in the `implementation-status-page` S-expression.

### Description
- Remove the stray closing parenthesis at the end of `implementation-status-page` in `web-site/src/completion.rkt` so the page markup now parses correctly.

### Testing
- No automated tests were run; this is a small syntax-only correction and has been committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f9c2bfa88322b1e9ce896681b04c)