### PR TITLE
Adjust dashboard progress gradient fill behavior

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -2829,8 +2829,9 @@
   (define missing (- total implemented-count))
   (define pct (if (zero? total) 0 (/ implemented-count total)))
   (define pct-num (format-percent pct))
+  (define pct-decimal (exact->inexact pct))
   (define tier (section-progress-tier pct-num))
-  (list title primitives implemented-count total missing pct-num tier (section-id title)))
+  (list title primitives implemented-count total missing pct-num pct-decimal tier (section-id title)))
 
 (define (section-card section implemented-set)
   (match section
@@ -2844,8 +2845,9 @@
      (define implemented-count (list-ref stats 2))
      (define total (list-ref stats 3))
      (define pct-num (list-ref stats 5))
-     (define tier (list-ref stats 6))
-     (define anchor-id (list-ref stats 7))
+     (define pct-decimal (list-ref stats 6))
+     (define tier (list-ref stats 7))
+     (define anchor-id (list-ref stats 8))
      (define aria-label
        (format "~a: ~a%, ~a of ~a primitives implemented"
                title pct-num implemented-count total))
@@ -2864,10 +2866,12 @@
                              (aria-label ,aria-label)
                              (aria-valuemin "0")
                              (aria-valuemax "100")
-                             (aria-valuenow ,(number->string pct-num)))
+                             (aria-valuenow ,(number->string pct-num))
+                             (style ,(format "--pct: ~a%; --pct-decimal: ~a;"
+                                             pct-num
+                                             pct-decimal)))
                           (div (@ (class ,(format "status-bar-fill status-bar-fill--~a"
-                                                  tier))
-                                  (style ,(format "width: ~a%;" pct-num))))))
+                                                  tier)))))))
                 (div (@ (class "status-summary-action"))
                      (span (@ (class "status-summary-text")) "View")
                      (span (@ (class "status-summary-chevron")) "▸")))

--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1493,13 +1493,21 @@ pre {
   border-radius: 999px;
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  --pct: 0%;
+  --pct-decimal: 0;
+  --pct-decimal-safe: max(var(--pct-decimal), 0.01);
 }
 .status-bar-fill {
   height: 100%;
+  width: var(--pct);
   background: linear-gradient(90deg, rgba(209, 58, 58, 0.85),
                                       rgba(242, 183, 5, 0.85),
                                       rgba(74, 108, 255, 0.9));
+  background-size: calc(100% / var(--pct-decimal-safe)) 100%;
+  background-position: left center;
+  background-repeat: no-repeat;
   box-shadow: 0 0 10px rgba(74, 108, 255, 0.2);
+  transition: width 220ms ease;
 }
 .status-bar-fill--low {
   background: linear-gradient(90deg, rgba(209, 58, 58, 0.92),


### PR DESCRIPTION
### Motivation
- Ensure the chapter-card progress bars show the portion of the gradient that corresponds to the filled width so early colors don’t show later gradient stops until the bar reaches them.

### Description
- Compute a per-section decimal percentage in `web-site/src/completion.rkt` (`pct-decimal`) and expose both `--pct` and `--pct-decimal` via the `style` attribute on the `.status-bar` element.
- Update CSS in `web-site/src/web-site.rkt` to render the gradient on the fill element itself and scale it to the fill width by using `width: var(--pct)` and `background-size: calc(100% / var(--pct-decimal-safe)) 100%` with `--pct-decimal-safe: max(var(--pct-decimal), 0.01)` to avoid divide-by-zero.
- Keep existing track styling (rounded corners, subtle border/shadow) and only change how the fill is painted; add `transition: width 220ms ease` for smooth updates.

### Testing
- Ran the site build script `web-site/src/build.sh` in this environment, which failed with `racket: command not found` so the generated site could not be produced for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979102fb1948322a663f21bf6a2a3dd)