### PR TITLE
Fix bracket mismatch in completion status bar markup

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -2871,7 +2871,7 @@
                                              pct-num
                                              pct-decimal)))
                           (div (@ (class ,(format "status-bar-fill status-bar-fill--~a"
-                                                  tier)))))))
+                                                  tier))))))
                 (div (@ (class "status-summary-action"))
                      (span (@ (class "status-summary-text")) "View")
                      (span (@ (class "status-summary-chevron")) "▸")))


### PR DESCRIPTION
### Motivation
- Fix a parse error in `web-site/src/completion.rkt` caused by an extra closing parenthesis in the status bar fill markup which made the file fail to read/compile.

### Description
- Remove the stray closing paren in the `status-bar-fill` markup line in `web-site/src/completion.rkt`, resolving the bracket mismatch and restoring valid S-expression structure.

### Testing
- No automated tests were run for this trivial one-line markup fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979156d9d888322b78ad94da12485fe)