### PR TITLE
Status dashboard: compress progress-bar gradient into filled width

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -2829,9 +2829,8 @@
   (define missing (- total implemented-count))
   (define pct (if (zero? total) 0 (/ implemented-count total)))
   (define pct-num (format-percent pct))
-  (define pct-decimal (exact->inexact pct))
   (define tier (section-progress-tier pct-num))
-  (list title primitives implemented-count total missing pct-num pct-decimal tier (section-id title)))
+  (list title primitives implemented-count total missing pct-num tier (section-id title)))
 
 (define (section-card section implemented-set)
   (match section
@@ -2845,9 +2844,8 @@
      (define implemented-count (list-ref stats 2))
      (define total (list-ref stats 3))
      (define pct-num (list-ref stats 5))
-     (define pct-decimal (list-ref stats 6))
-     (define tier (list-ref stats 7))
-     (define anchor-id (list-ref stats 8))
+     (define tier (list-ref stats 6))
+     (define anchor-id (list-ref stats 7))
      (define aria-label
        (format "~a: ~a%, ~a of ~a primitives implemented"
                title pct-num implemented-count total))
@@ -2867,9 +2865,7 @@
                              (aria-valuemin "0")
                              (aria-valuemax "100")
                              (aria-valuenow ,(number->string pct-num))
-                             (style ,(format "--pct: ~a%; --pct-decimal: ~a;"
-                                             pct-num
-                                             pct-decimal)))
+                             (style ,(format "--pct: ~a;" pct-num)))
                           (div (@ (class ,(format "status-bar-fill status-bar-fill--~a"
                                                   tier))))))
                 (div (@ (class "status-summary-action"))

--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1493,35 +1493,37 @@ pre {
   border-radius: 999px;
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-  --pct: 0%;
-  --pct-decimal: 0;
-  --pct-decimal-safe: max(var(--pct-decimal), 0.01);
+  --pct: 0;
+  --p: clamp(0, calc(var(--pct) / 100), 1);
+  --p-safe: max(var(--p), 0.001);
 }
 .status-bar-fill {
   height: 100%;
-  width: var(--pct);
-  background: linear-gradient(90deg, rgba(209, 58, 58, 0.85),
-                                      rgba(242, 183, 5, 0.85),
-                                      rgba(74, 108, 255, 0.9));
-  background-size: calc(100% / var(--pct-decimal-safe)) 100%;
-  background-position: left center;
+  width: calc(var(--p) * 100%);
+  background: var(--progress-gradient);
+  background-size: calc(100% / var(--p-safe)) 100%;
+  background-position: 0 50%;
   background-repeat: no-repeat;
+  border-radius: inherit;
   box-shadow: 0 0 10px rgba(74, 108, 255, 0.2);
   transition: width 220ms ease;
+  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.85),
+                                               rgba(242, 183, 5, 0.85),
+                                               rgba(74, 108, 255, 0.9));
 }
 .status-bar-fill--low {
-  background: linear-gradient(90deg, rgba(209, 58, 58, 0.92),
-                                      rgba(242, 183, 5, 0.65));
+  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.92),
+                                               rgba(242, 183, 5, 0.65));
   box-shadow: 0 0 12px rgba(209, 58, 58, 0.28);
 }
 .status-bar-fill--mid {
-  background: linear-gradient(90deg, rgba(242, 183, 5, 0.78),
-                                      rgba(74, 108, 255, 0.82));
+  --progress-gradient: linear-gradient(90deg, rgba(242, 183, 5, 0.78),
+                                               rgba(74, 108, 255, 0.82));
   box-shadow: 0 0 12px rgba(74, 108, 255, 0.18);
 }
 .status-bar-fill--strong {
-  background: linear-gradient(90deg, rgba(74, 108, 255, 0.92),
-                                      rgba(101, 79, 240, 0.94));
+  --progress-gradient: linear-gradient(90deg, rgba(74, 108, 255, 0.92),
+                                               rgba(101, 79, 240, 0.94));
   box-shadow: 0 0 12px rgba(101, 79, 240, 0.32);
 }
 .status-body {


### PR DESCRIPTION
### Motivation
- The progress bar gradient previously extended across the full track and bled into the unfilled area instead of being compressed to the filled width.
- The intent is to show only the left portion of the gradient proportional to the fill so a 50% fill shows half the gradient range and 100% shows the full range.

### Description
- Change CSS to emit a numeric `--pct` on the `.status-bar` and compute a fraction `--p: calc(var(--pct) / 100)` clamped to `[0,1]` and a safe fallback `--p-safe` for scaling.
- Update the fill element to use `width: calc(var(--p) * 100%)`, a single canonical gradient `--progress-gradient`, and `background-size: calc(100% / var(--p-safe)) 100%` with `background-position: 0 50%` and `background-repeat: no-repeat` so the gradient is zoomed and clipped to the filled portion.
- Preserve rounded ends by using `border-radius: inherit` on the fill and keep per-tier color variants by exposing `--progress-gradient` in the tier modifiers (`.status-bar-fill--low`, `--mid`, `--strong`).
- Remove the older `--pct-decimal` plumbing and clamp progress in CSS to handle out-of-range values safely.

### Testing
- No automated tests were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69791ab57c78832293c685c6070c74a9)