### PR TITLE
Refine status primitive list layout

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1527,35 +1527,34 @@ pre {
   box-shadow: 0 0 12px rgba(101, 79, 240, 0.32);
 }
 .status-body {
-  padding: 0 20px 20px;
+  padding: 0 18px 14px;
 }
 .status-list {
   list-style: none;
   padding: 0;
   margin: 0;
   display: grid;
-  gap: 12px;
-  margin-top: 16px;
+  gap: 8px;
+  margin-top: 10px;
 }
 .prim-row {
   display: grid;
   grid-template-columns: 140px minmax(0, 1fr);
   align-items: center;
-  gap: 14px;
-  padding: 12px 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  gap: 12px;
+  padding: 8px 14px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.04);
 }
 .prim-row--link {
   text-decoration: none;
   color: inherit;
-  transition: background 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+  transition: background 150ms ease, border-color 150ms ease;
 }
 .prim-row--link:hover {
-  background: rgba(74, 108, 255, 0.08);
-  border-color: rgba(74, 108, 255, 0.25);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+  background: rgba(74, 108, 255, 0.06);
+  border-color: rgba(74, 108, 255, 0.2);
 }
 .prim-row--link:focus-visible {
   outline: 2px solid rgba(74, 108, 255, 0.7);
@@ -1567,9 +1566,9 @@ pre {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 12px;
+  padding: 6px 10px;
   border-radius: 999px;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
 }
 .prim-name {
@@ -2276,8 +2275,8 @@ pre code {
 @media (max-width: 520px) {
   .prim-row {
     grid-template-columns: 120px minmax(0, 1fr);
-    gap: 12px;
-    padding: 10px 12px;
+    gap: 10px;
+    padding: 8px 12px;
   }
   .prim-badge {
     width: 120px;


### PR DESCRIPTION
### Motivation
- Tighten the expanded chapter card primitive list so rows read as compact, subordinate list rows with improved alignment and scannability.

### Description
- Reduced per-row vertical padding and gap, lowered background contrast, reduced border-radius and border opacity, and removed the heavy hover shadow to make rows visually lighter than the parent card.
- Kept the fixed-width badge column (grid: `140px 1fr`) and adjusted badge padding/size so all function names begin at the same x-position and badges remain readable at the new row height.
- Ensured function names are hard-left aligned and do not wrap by using `min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;` and preserved the `title` attribute on the link for full-name tooltips (no structural changes except CSS tweaks and responsive badge sizing).
- Tightened the list container spacing and reduced top/bottom padding so the expanded list becomes a compact sub-surface of the chapter card.

### Testing
- Executed the site build script `./web-site/src/build.sh` to exercise the change, but the build failed in this environment because `racket` is not installed; no rendered snapshots could be produced.
- Verified the CSS changes were applied in `web-site/src/web-site.rkt` and are self-contained to the status list styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979239e5c4883228c7cbb602e7d8a06)