### PR TITLE
Adjust status chapter grid layout

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1414,9 +1414,23 @@ pre {
 }
 .status-chapter-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 16px;
-  --card-max-w: 380px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 22px;
+  align-items: stretch;
+}
+@media (max-width: 1100px) {
+  .status-chapter-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 700px) {
+  .status-chapter-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.status-chapter-grid > * {
+  width: 100%;
+  min-width: 0;
 }
 .status-section {
   background: var(--surface);
@@ -1424,8 +1438,7 @@ pre {
   border-radius: 20px;
   overflow: hidden;
   transition: transform 150ms ease, border-color 150ms ease;
-  max-width: var(--card-max-w);
-  justify-self: start;
+  min-width: 0;
 }
 .status-section[open] {
   grid-column: 1 / -1;


### PR DESCRIPTION
### Motivation
- Prevent uneven/ragged column widths in the status chapter card grid by replacing the current auto-fit flex/grid hybrid with a deterministic grid layout.
- Ensure long section titles cannot force column resizing so rows keep consistent card widths across breakpoints.

### Description
- Replaced the existing `.status-chapter-grid` sizing with a CSS Grid using `grid-template-columns: repeat(4, minmax(0, 1fr))` and `align-items: stretch` for consistent columns.
- Added responsive breakpoints to change the grid to `repeat(2, minmax(0, 1fr))` at `@media (max-width: 1100px)` and to a single column at `@media (max-width: 700px)`.
- Ensured grid items and cards can shrink by adding `.status-chapter-grid > * { width: 100%; min-width: 0; }` and setting `.status-section { min-width: 0; }` to prevent long titles from expanding columns.
- Increased the grid gap to `22px` and removed the previous `max-width` hack that caused uneven card widths.

### Testing
- N/A.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793f043a7c83228dfab782c17b4657)