### PR TITLE
Add interactive status sorting for identifier lists

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1690,6 +1690,16 @@ pre {
   letter-spacing: 0.04em;
   font-weight: 600;
 }
+.status-chip--filter {
+  cursor: pointer;
+}
+.status-chip--filter:focus-visible {
+  outline: 2px solid rgba(74, 108, 255, 0.6);
+  outline-offset: 2px;
+}
+.status-chip--active {
+  box-shadow: 0 0 0 1px rgba(233, 236, 255, 0.6);
+}
 .status-chip--done {
   background: rgba(74, 108, 255, 0.18);
   color: #C9D5FF;


### PR DESCRIPTION
### Motivation
- Make the expanded identifier lists in each status card interactive so users can group and order identifiers by implementation status without changing existing layout or visual design.
- Provide per-card state so sorting works independently for each expanded section and is keyboard-accessible.

### Description
- Convert the three status chips into `<button type="button">` elements and add `data-status-group` attributes plus `aria-pressed` to indicate state. 
- Add a small client-side script (`status-filter-script`) that maintains per-card `activeGroup` and `activeDir`, computes a priority order (`implemented | stdlib | missing` rotated by the active group), and performs a stable decorate-sort-undecorate to reorder `.status-list` items accordingly.
- Implement the click/toggle behavior so clicking a different pill sets `activeGroup` and resets `activeDir` to `asc`, while clicking the same pill toggles `activeDir` between `asc` and `desc`.
- Add minimal CSS hooks (`.status-chip--filter`, `.status-chip--active`) and reuse existing chip styles so the visual design is unchanged; buttons receive focus-visible outlines for keyboard accessibility.

### Testing
- Ran `./build.sh` to exercise the site build and embedded scripts, but the build failed in this environment due to `racket` not being available (no site artifacts produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69794639cc488322a878e0d5132f5535)