### PR TITLE
Tighten status dashboard card spacing and progress bars

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1283,10 +1283,12 @@ pre {
   box-shadow: 0 16px 30px rgba(0, 0, 0, 0.26);
 }
 .page--status {
-  --status-card-padding: 14px;
-  --status-card-gap: 8px;
-  --status-section-spacing: 60px;
-  --status-progress-height: 6px;
+  --status-card-padding: 12px;
+  --status-card-gap: 6px;
+  --status-section-spacing: 44px;
+  --status-progress-height: 4px;
+  --status-attention-padding: 10px;
+  --status-attention-gap: 5px;
 }
 .page--status .card {
   background: rgba(255, 255, 255, 0.03);
@@ -1314,13 +1316,13 @@ pre {
   margin-top: var(--status-section-spacing);
 }
 .section--status .section-header {
-  margin-bottom: calc(var(--status-card-gap) * 2);
+  margin-bottom: calc(var(--status-card-gap) * 1.6);
 }
 .section--status .section-title + * {
-  margin-top: calc(var(--status-card-gap) * 1.5);
+  margin-top: calc(var(--status-card-gap) * 1.2);
 }
 .status-insight {
-  margin-top: calc(var(--status-card-gap) * 2);
+  margin-top: calc(var(--status-card-gap) * 1.5);
 }
 .status-insight .callout {
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.28);
@@ -1337,8 +1339,8 @@ pre {
   color: var(--text);
 }
 .attention-grid .card {
-  padding: var(--status-card-padding);
-  gap: var(--status-card-gap);
+  padding: var(--status-attention-padding);
+  gap: var(--status-attention-gap);
 }
 .attention-grid {
   grid-template-columns: minmax(0, 1fr);
@@ -1364,6 +1366,11 @@ pre {
   align-items: baseline;
   gap: 12px;
 }
+.attention-header h3 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+}
 .attention-percent {
   font-weight: 600;
   color: var(--text);
@@ -1373,11 +1380,17 @@ pre {
   margin: 0;
   color: var(--muted);
   font-size: 0.85rem;
+  line-height: 1.2;
+  min-height: 1.2em;
 }
 .attention-note {
   margin: 0;
   color: rgba(182, 189, 221, 0.92);
   font-size: 0.9rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 .attention-link {
   display: inline-flex;
@@ -1388,10 +1401,11 @@ pre {
   color: #C9D5FF;
   text-decoration: none;
   border-radius: 999px;
-  padding: calc(var(--status-card-gap) / 2) calc(var(--status-card-gap) + 2px);
+  padding: calc(var(--status-attention-gap) / 2) calc(var(--status-attention-gap) + 4px);
   background: rgba(74, 108, 255, 0.15);
   border: 1px solid rgba(74, 108, 255, 0.35);
   transition: transform 150ms ease, box-shadow 150ms ease, color 150ms ease;
+  min-height: 28px;
 }
 .attention-link:hover,
 .attention-link:focus-visible {
@@ -1439,12 +1453,12 @@ pre {
 .status-chapters {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--status-card-gap) * 2);
+  gap: calc(var(--status-card-gap) * 1.5);
 }
 .status-chapter {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--status-card-gap) * 1.5);
+  gap: calc(var(--status-card-gap) * 1.2);
 }
 .status-chapter-header h3 {
   margin: 0;
@@ -1453,7 +1467,7 @@ pre {
 .status-chapter-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: calc(var(--status-card-gap) * 2);
+  gap: calc(var(--status-card-gap) * 1.6);
   align-items: stretch;
 }
 @media (max-width: 1100px) {
@@ -1494,7 +1508,7 @@ pre {
   cursor: pointer;
   list-style: none;
   transition: background 150ms ease, border-color 150ms ease;
-  --meter-w: 132px;
+  --meter-w: 150px;
 }
 .status-summary:hover {
   background: rgba(74, 108, 255, 0.08);
@@ -1509,27 +1523,29 @@ pre {
 .status-summary-main {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--status-card-gap) / 2);
+  gap: calc(var(--status-card-gap) / 3);
   min-width: 0;
 }
 .status-title {
   margin: 0;
   font-size: 1.05rem;
   white-space: nowrap;
-  overflow: visible;
-  text-overflow: clip;
+  overflow: hidden;
+  text-overflow: ellipsis;
   min-width: 0;
 }
 .status-count {
   margin: 0;
   color: var(--muted);
   font-size: 0.85rem;
+  line-height: 1.2;
+  min-height: 1.2em;
 }
 .status-summary-metric {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: calc(var(--status-card-gap) / 2);
+  gap: calc(var(--status-card-gap) / 3);
 }
 .status-summary-action {
   display: inline-flex;
@@ -1539,6 +1555,7 @@ pre {
   font-size: 0.75rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  min-height: 1em;
 }
 .status-summary-chevron {
   font-size: 1rem;
@@ -1572,30 +1589,30 @@ pre {
   background-position: 0 50%;
   background-repeat: no-repeat;
   border-radius: inherit;
-  box-shadow: 0 0 10px rgba(74, 108, 255, 0.2);
+  box-shadow: 0 0 6px rgba(74, 108, 255, 0.18);
   transition: width 220ms ease;
-  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.85),
-                                               rgba(242, 183, 5, 0.85),
-                                               rgba(74, 108, 255, 0.9));
+  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.78),
+                                               rgba(242, 183, 5, 0.78),
+                                               rgba(74, 108, 255, 0.82));
 }
 .status-bar-fill--low {
-  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.92),
-                                               rgba(242, 183, 5, 0.65));
-  box-shadow: 0 0 12px rgba(209, 58, 58, 0.28);
+  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.82),
+                                               rgba(242, 183, 5, 0.6));
+  box-shadow: 0 0 8px rgba(209, 58, 58, 0.22);
 }
 .status-bar-fill--mid {
-  --progress-gradient: linear-gradient(90deg, rgba(242, 183, 5, 0.78),
-                                               rgba(74, 108, 255, 0.82));
-  box-shadow: 0 0 12px rgba(74, 108, 255, 0.18);
+  --progress-gradient: linear-gradient(90deg, rgba(242, 183, 5, 0.7),
+                                               rgba(74, 108, 255, 0.76));
+  box-shadow: 0 0 8px rgba(74, 108, 255, 0.16);
 }
 .status-bar-fill--strong {
-  --progress-gradient: linear-gradient(90deg, rgba(74, 108, 255, 0.92),
-                                               rgba(101, 79, 240, 0.94));
-  box-shadow: 0 0 12px rgba(101, 79, 240, 0.32);
+  --progress-gradient: linear-gradient(90deg, rgba(74, 108, 255, 0.82),
+                                               rgba(101, 79, 240, 0.86));
+  box-shadow: 0 0 8px rgba(101, 79, 240, 0.24);
 }
 @media (min-width: 720px) and (max-width: 999px) {
   .status-summary {
-    --meter-w: 200px;
+    --meter-w: 220px;
   }
 }
 @media (max-width: 719px) {
@@ -1610,13 +1627,13 @@ pre {
   }
 }
 .status-body {
-  padding: calc(var(--status-card-gap) / 2) var(--status-card-padding) var(--status-card-gap);
+  padding: calc(var(--status-card-gap) / 2) var(--status-card-padding) calc(var(--status-card-gap) * 0.75);
   overflow-x: visible;
   overflow-y: visible;
 }
 .status-section[open] .status-body {
-  margin-top: var(--status-card-gap);
-  padding-top: var(--status-card-gap);
+  margin-top: calc(var(--status-card-gap) * 0.8);
+  padding-top: calc(var(--status-card-gap) * 0.8);
   border-top: 1px solid rgba(255, 255, 255, 0.06);
   background: rgba(255, 255, 255, 0.02);
 }
@@ -1626,7 +1643,7 @@ pre {
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
-  padding: 0 2px calc(var(--status-card-gap) / 2);
+  padding: 0 2px calc(var(--status-card-gap) / 3);
 }
 .status-body-legend {
   display: flex;
@@ -1658,7 +1675,7 @@ pre {
   margin: 0;
   display: grid;
   gap: var(--status-card-gap);
-  margin-top: calc(var(--status-card-gap) / 2);
+  margin-top: calc(var(--status-card-gap) / 3);
   overflow-x: auto;
   max-width: 100%;
   scrollbar-color: rgba(255, 255, 255, 0.18) transparent;


### PR DESCRIPTION
### Motivation
- Reduce collapsed-card height variance and overall vertical whitespace to produce more uniform dashboard rows while keeping existing behavior and grouping logic intact.
- Make progress bars wider for readability but thinner and visually lighter so labels dominate the visual weight.

### Description
- Updated shared spacing tokens and compacted card spacing in `web-site/src/web-site.rkt`, setting `--status-card-padding: 12px`, `--status-card-gap: 6px`, `--status-section-spacing: 44px`, and `--status-progress-height: 4px`, and added `--status-attention-padding` and `--status-attention-gap` for the Needs attention band.
- Constrained collapsed-card text layout by clamping attention descriptions to two lines and forcing single-line attention and section titles (status titles use ellipsis for overflow) to stabilize grid row heights.
- Reduced vertical gaps and padding across status summary/body/header/list elements and compacted the Needs attention cards so CTA/meta rows have consistent heights.
- Widened the status meter (`--meter-w` to 150px, 220px at mid breakpoints), reduced bar height and glow, and softened progress gradients to make the bar thinner and less visually dominant.

### Testing
- Ran `./build.sh` in `web-site/src`, which attempted to build the site but exited early because `racket` is not available in the environment (static CSS changes applied to `web-site/src/web-site.rkt`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697952866ed88322b372365d8e519648)