### PR TITLE
Tighten status dashboard density and progress bars

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1283,16 +1283,16 @@ pre {
   box-shadow: 0 16px 30px rgba(0, 0, 0, 0.26);
 }
 .page--status {
-  --status-card-padding: 11px;
-  --status-card-gap: 6px;
-  --status-stack-gap-base: 3px;
+  --status-card-padding: 10px;
+  --status-card-gap: 5.5px;
+  --status-stack-gap-base: 2.8px;
   --status-stack-gap: var(--status-stack-gap-base);
-  --status-section-spacing: 35px;
-  --status-section-padding-y: 26px;
-  --status-section-padding-x: 22px;
+  --status-section-spacing: 32px;
+  --status-section-padding-y: 24px;
+  --status-section-padding-x: 20px;
   --status-section-header-gap: calc(var(--status-card-gap) * 1.3);
   --status-section-title-gap: calc(var(--status-card-gap) * 0.9);
-  --status-progress-height: 2.6px;
+  --status-progress-height: 2.3px;
   --status-progress-label-height: 1.05rem;
   --status-progress-row-height: calc(var(--status-progress-label-height) + var(--status-progress-height) + var(--status-stack-gap));
   --status-title-line-height: 1.2em;
@@ -1300,8 +1300,8 @@ pre {
   --status-desc-line-height: 1.35em;
   --status-cta-line-height: 1.1em;
   --status-cta-height: 26px;
-  --status-attention-padding: 9px;
-  --status-attention-gap: 4px;
+  --status-attention-padding: 8px;
+  --status-attention-gap: 3.5px;
 }
 .page--status .card {
   background: rgba(255, 255, 255, 0.03);
@@ -1612,10 +1612,10 @@ pre {
   width: min(var(--meter-w), 100%);
   max-width: var(--meter-w);
   height: var(--status-progress-height);
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.1);
   border-radius: 999px;
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   --pct: 0;
   --p: clamp(0, calc(var(--pct) / 100), 1);
   --p-safe: max(var(--p), 0.001);
@@ -1628,26 +1628,26 @@ pre {
   background-position: 0 50%;
   background-repeat: no-repeat;
   border-radius: inherit;
-  box-shadow: 0 0 3px rgba(74, 108, 255, 0.1);
+  box-shadow: 0 0 2px rgba(74, 108, 255, 0.08);
   transition: width 220ms ease;
-  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.62),
-                                               rgba(242, 183, 5, 0.62),
-                                               rgba(74, 108, 255, 0.64));
+  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.56),
+                                               rgba(242, 183, 5, 0.56),
+                                               rgba(74, 108, 255, 0.58));
 }
 .status-bar-fill--low {
-  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.66),
-                                               rgba(242, 183, 5, 0.48));
-  box-shadow: 0 0 4px rgba(209, 58, 58, 0.12);
+  --progress-gradient: linear-gradient(90deg, rgba(209, 58, 58, 0.6),
+                                               rgba(242, 183, 5, 0.44));
+  box-shadow: 0 0 3px rgba(209, 58, 58, 0.1);
 }
 .status-bar-fill--mid {
-  --progress-gradient: linear-gradient(90deg, rgba(242, 183, 5, 0.56),
-                                               rgba(74, 108, 255, 0.6));
-  box-shadow: 0 0 4px rgba(74, 108, 255, 0.1);
+  --progress-gradient: linear-gradient(90deg, rgba(242, 183, 5, 0.5),
+                                               rgba(74, 108, 255, 0.54));
+  box-shadow: 0 0 3px rgba(74, 108, 255, 0.08);
 }
 .status-bar-fill--strong {
-  --progress-gradient: linear-gradient(90deg, rgba(74, 108, 255, 0.64),
-                                               rgba(101, 79, 240, 0.66));
-  box-shadow: 0 0 4px rgba(101, 79, 240, 0.12);
+  --progress-gradient: linear-gradient(90deg, rgba(74, 108, 255, 0.58),
+                                               rgba(101, 79, 240, 0.6));
+  box-shadow: 0 0 3px rgba(101, 79, 240, 0.1);
 }
 @media (min-width: 720px) and (max-width: 999px) {
   .status-summary {
@@ -1816,8 +1816,8 @@ pre {
 .status-cta {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 11px 18px;
+  gap: 10px;
+  padding: 9px 18px;
   background: rgba(255, 255, 255, 0.02);
   border-radius: 20px;
   border: 1px solid rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
### Motivation
- Restore the Implementation Status dashboard "instrument panel" density and table-like grid rhythm by tightening shared spacing tokens and quieting progress bar visuals without changing behavior or clipping content.

### Description
- Adjusted shared status spacing tokens in `web-site/src/web-site.rkt` to tighten vertical rhythm: `--status-card-padding: 10px` (from 11px), `--status-card-gap: 5.5px` (from 6px), `--status-stack-gap-base: 2.8px` (from 3px), `--status-section-spacing: 32px` (from 35px), `--status-section-padding-y: 24px` (from 26px), and `--status-section-padding-x: 20px` (from 22px).
- Slimmed progress bar height and visuals while keeping width behavior unchanged by setting `--status-progress-height: 2.3px` (was 2.6px), reducing bar background alpha to `rgba(255,255,255,0.1)` (was 0.12), lowering inset stroke to `rgba(255,255,255,0.04)`, reducing fill glow from `0 0 3px rgba(74,108,255,0.1)` to `0 0 2px rgba(74,108,255,0.08)`, and reducing gradient alphas across `--progress-gradient` and the `.status-bar-fill--*` variants.
- Shortened the footer CTA band and made it quieter by reducing `.status-cta` `gap` to `10px` (from 12px) and `padding` to `9px 18px` (from `11px 18px`).
- Kept and confirmed the collapsed prose 2-line clamp and reserving min-height: `.attention-note` uses `line-height: var(--status-desc-line-height); min-height: calc(var(--status-desc-line-height) * 2); display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;` so collapsed descriptions clamp to two lines and reserve 2-line space.
- Ensured card/grid overflow safety by not adding `overflow: hidden` to card root, card main wrappers, or grid item wrappers; only the collapsed prose element uses `overflow: hidden` for the clamp.

### Testing
- Attempted local site build via `./build.sh` in `web-site/src`, but the build could not run because `racket` is not available in the environment; no runtime visual tests executed.

Files changed
- `web-site/src/web-site.rkt`

Where the prose 2-line clamp & min-height are defined
- Selector: `.attention-note` in `web-site/src/web-site.rkt` (keeps):
  - `line-height: var(--status-desc-line-height);`
  - `min-height: calc(var(--status-desc-line-height) * 2);`
  - `display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;`

Exact progress bar height / spacing / intensity changes
- `--status-progress-height: 2.3px` (previously `2.6px`).
- `.status-bar` background changed to `rgba(255, 255, 255, 0.1)` (was `0.12`) and inset stroke to `rgba(255,255,255,0.04)` (was `0.05`).
- `.status-bar-fill` outer glow reduced from `0 0 3px rgba(74,108,255,0.1)` to `0 0 2px rgba(74,108,255,0.08)`.
- Fill gradients alpha values lowered across `--progress-gradient` and `.status-bar-fill--low|--mid|--strong` (see `web-site/src/web-site.rkt` for exact linear-gradient values).
- Width behavior unchanged: `.status-bar` still uses `width: min(var(--meter-w), 100%);` and fill width still driven by `--pct`.

Exact section / card spacing adjustments
- `--status-card-padding: 10px` (from `11px`).
- `--status-card-gap: 5.5px` (from `6px`).
- `--status-stack-gap-base: 2.8px` (from `3px`).
- `--status-section-spacing: 32px` (from `35px`).
- `--status-section-padding-y: 24px` (from `26px`).
- `--status-section-padding-x: 20px` (from `22px`).
- Attention grid tuned: `--status-attention-padding: 8px` (from 9px) and `--status-attention-gap: 3.5px` (from 4px).
- `.status-cta` gap/padding reduced to `gap: 10px; padding: 9px 18px;` (from `12px` / `11px 18px`).

Overflow safety confirmation
- No `overflow: hidden` was added to the following selectors: `.card`, `.status-summary`, `.status-section` (root), `.status-chapter-grid`, or `.card-grid`.
- The only element intentionally using `overflow: hidden` is the collapsed prose clamp `.attention-note` (see selector above).

If you want, I can: 1) run a quick visual sanity check (build + open the generated HTML) if `racket` is available in the environment, or 2) prepare a tiny screenshot runner that can be used locally to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795f10d6fc8322afd77c903960c840)