### PR TITLE
Port status dashboard scripts to WebRacket handlers

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -2514,7 +2514,10 @@ CSS
   
   (define page (sxml->dom page-structure))
   
-  (js-append-child! body page))
+  (js-append-child! body page)
+
+  (when (eq? (current-page) 'implementation-status)
+    (init-status-page-handlers!)))
 
 ;;;
 ;;; Entry Point


### PR DESCRIPTION
### Motivation
- Replace embedded JavaScript used to power the Implementation Status dashboard with native WebRacket DOM handlers to keep behavior in Racket and reuse the project’s JS FFI helpers.
- Make the dashboard behavior (smooth scrolling to sections, filtering and sorting primitives, and collapse buttons) attach after the page DOM is rendered.

### Description
- Removed inline JS strings previously emitted by `status-smooth-scroll-script` and `status-filter-script` in `web-site/src/completion.rkt` and implemented equivalent WebRacket handlers and helpers (`node-list->list`, `classlist-contains?`, `element-text`, `status-open-target!`, `init-status-smooth-scroll!`, `init-status-filter!`, `init-status-collapse-buttons!`, and `init-status-page-handlers!`).
- Replaced the inline `onclick` attribute on the collapse button with a button-only element and attached a Racket handler that calls `closest` and removes the `open` attribute.
- Added a hook in `web-site/src/web-site.rkt` so `init-status-page-handlers!` is invoked after the status page is rendered (`when (eq? (current-page) 'implementation-status) (init-status-page-handlers!)`).
- Adjusted NodeList iteration to use `js-send ... "item"` and `js-ref ... "length"` for portability in the WebRacket environment.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a12f3b354832286df4a193715a297)