### PR TITLE
Fix status list class detection for sorting

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3074,7 +3074,11 @@
 (define (classlist-contains? element class-name)
   (define class-list (js-ref element "classList"))
   (and class-list
-       (not (zero? (js-send class-list "contains" (vector class-name))))))
+       (let ([result (js-send class-list "contains" (vector class-name))])
+         (cond
+           [(boolean? result) result]
+           [(number? result) (not (zero? result))]
+           [else #f]))))
 
 (define (element-text element)
   (define content (and element (js-ref element "textContent")))


### PR DESCRIPTION
### Motivation
- Avoid a runtime "unreachable" error when sorting status list items caused by `classList.contains` returning a boolean (which then flowed into `(zero? ...)` expecting a number).

### Description
- Update `classlist-contains?` to inspect the result of `js-send classList "contains"` and return the boolean directly when it's a boolean, treat numeric 0/1 as false/true, and otherwise return `#f`.

### Testing
- No automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a1603250083228e33c9f72efc07e8)