### PR TITLE
Fix status chip grouping detection

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3071,14 +3071,16 @@
         (loop (add1 idx)
               (cons (js-send node-list "item" (vector idx)) acc)))))
 
+(define status-handler-store '())
+
+(define (remember-status-handler! handler)
+  (set! status-handler-store (cons handler status-handler-store))
+  (void))
+
 (define (classlist-contains? element class-name)
-  (define class-list (js-ref element "classList"))
-  (and class-list
-       (let ([result (js-send class-list "contains" (vector class-name))])
-         (cond
-           [(boolean? result) result]
-           [(number? result) (not (zero? result))]
-           [else #f]))))
+  (define selector (string-append "." class-name))
+  (define result (and element (js-matches element selector)))
+  (and (number? result) (not (zero? result))))
 
 (define (element-text element)
   (define content (and element (js-ref element "textContent")))
@@ -3111,6 +3113,7 @@
            (js-send (js-window-history) "replaceState"
                     (vector (js-null) "" (string-append "#" target-id))))
          (void))))
+    (remember-status-handler! handler)
     (js-add-event-listener! link "click" handler))
   (define hash (js-ref (js-window-location) "hash"))
   (when (and (string? hash) (> (string-length hash) 1))
@@ -3210,6 +3213,7 @@
                      (set! active-dir "asc")))
                (sync-and-sort!))
              (void))))
+        (remember-status-handler! handler)
         (js-add-event-listener! button "click" handler))
       (sync-and-sort!)))
   (void))
@@ -3224,6 +3228,7 @@
          (when details
            (js-remove-attribute! details "open"))
          (void))))
+    (remember-status-handler! handler)
     (js-add-event-listener! button "click" handler))
   (void))
 


### PR DESCRIPTION
### Motivation
- Restore correct grouping/sorting and click interactions on the Implementation Status dashboard by fixing how status classes are detected and ensuring externally-registered event handlers remain live.
- The previous class-check path relied on a JS value that wasn’t reliably interpreted by the runtime, causing rows to be treated as “missing” and making filter clicks appear ineffective.

### Description
- Add `status-handler-store` and `remember-status-handler!` to retain references to `procedure->external` callbacks so exported extern callbacks are not dropped by the runtime.
- Replace the `classList.contains`-based check with `js-matches` in `classlist-contains?`, converting the numeric JS return into a Racket truth value via `(and (number? result) (not (zero? result)))` so implemented/stdlib rows are correctly detected.
- Register handlers with `remember-status-handler!` in `init-status-smooth-scroll!`, `init-status-filter!`, and `init-status-collapse-buttons!` so the click handlers remain live and functioning.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a1a8d3aac8322b8dfbf7fd0530f8b)