### PR TITLE
Use function names for contract comment headers in completion.rkt

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3,10 +3,10 @@
 ;;; Included by web-site.rkt to render the WebRacket status page.
 ;;;
 
-;; Contract: (listof symbol?) -> (listof symbol?)
+;; sort-symbols: (listof symbol?) -> (listof symbol?)
 ;;   Return a sorted list of symbols using symbol<? ordering.
 (define (sort-symbols syms)
-  ;; Contract: symbol? (listof symbol?) -> (listof symbol?)
+  ;; insert: symbol? (listof symbol?) -> (listof symbol?)
   ;;   Insert a symbol into a sorted list.
   (define (insert sym lst)
     (if (null? lst)
@@ -1548,7 +1548,7 @@
     ; todo : implement string-titlecase
     (string-titlecase (symbol->string s)))
 
-;; Contract: symbol? -> string?
+;; symbol->title: symbol? -> string?
 ;;   Convert a symbol into a title string for headings.
 (define (symbol->title s)
   (symbol->string s))
@@ -2769,18 +2769,18 @@
 ; (js-log prepared-chapters)
 
 
-;; Contract: real? -> exact-integer?
+;; format-percent: real? -> exact-integer?
 ;;   Convert a 0-1 progress ratio into a rounded percentage.
 (define (format-percent pct)
   (inexact->exact (round (* 100 pct))))
 
-;; Contract: symbol? -> string?
+;; primitive-url: symbol? -> string?
 ;;   Build the Racket documentation URL for a primitive.
 (define (primitive-url sym)
   (string-append "https://docs.racket-lang.org/search/index.html?q="
                  (symbol->string sym)))
 
-;; Contract: symbol? (listof symbol?) -> (values string? string?)
+;; primitive-status: symbol? (listof symbol?) -> (values string? string?)
 ;;   Classify a primitive by implementation status.
 (define (primitive-status sym implemented-set)
   (cond
@@ -2788,7 +2788,7 @@
     [(memq sym implemented-set)              (values "status-chip status-chip--done"   "Implemented")]
     [else                                    (values "status-chip status-chip--todo"   "Missing")]))
 
-;; Contract: symbol? (listof symbol?) -> list?
+;; primitive-item: symbol? (listof symbol?) -> list?
 ;;   Render a primitive list item with status badge and link.
 (define (primitive-item sym implemented-set)
   (define-values (status-class status-label) (primitive-status sym implemented-set))
@@ -2806,10 +2806,10 @@
        (span (@ (class ,(string-append status-class " prim-badge"))) ,status-label)
        (span (@ (class "prim-name") (title ,name)) ,name))))
 
-;; Contract: string? -> string?
+;; section-id: string? -> string?
 ;;   Create a stable HTML id from a section title.
 (define (section-id title)
-  ;; Contract: char? -> boolean?
+  ;; ascii-alnum?: char? -> boolean?
   ;;   Build a slug without regex: ASCII alphanumerics separated by single hyphens.
   ;;   Recognize ASCII lowercase letters and digits.
   (define (ascii-alnum? ch)
@@ -2836,14 +2836,14 @@
   (define cleaned (list->string (reverse trimmed-rev)))
   (string-append "section-" (if (string=? cleaned "") "untitled" cleaned)))
 
-;; Contract: (listof symbol?) (listof symbol?) -> exact-nonnegative-integer?
+;; section-implemented-count: (listof symbol?) (listof symbol?) -> exact-nonnegative-integer?
 ;;   Count implemented primitives in a section.
 (define (section-implemented-count primitives implemented-set)
   (for/sum ([p (in-list primitives)]
             #:when (memq p implemented-set))
     1))
 
-;; Contract: real? -> string?
+;; section-progress-tier: real? -> string?
 ;;   Map progress percentage to a UI tier label.
 (define (section-progress-tier pct-num)
   (cond
@@ -2851,7 +2851,7 @@
     [(> pct-num 80) "strong"]
     [else "mid"]))
 
-;; Contract: string? (listof symbol?) (listof symbol?) -> list?
+;; section-stats: string? (listof symbol?) (listof symbol?) -> list?
 ;;   Compute summary stats for a section.
 (define (section-stats title primitives implemented-set)
   (define implemented-count (section-implemented-count primitives implemented-set))
@@ -2862,7 +2862,7 @@
   (define tier (section-progress-tier pct-num))
   (list title primitives implemented-count total missing pct-num tier (section-id title)))
 
-;; Contract: list? (listof symbol?) -> list?
+;; section-card: list? (listof symbol?) -> list?
 ;;   Render a status card for a section of primitives.
 (define (section-card section implemented-set)
   (match section
@@ -2931,7 +2931,7 @@
                 ,@(map (λ (sym) (primitive-item sym implemented-set))
                        (sort-symbols primitives)))))]))
 
-;; Contract: list? -> list?
+;; chapter-block: list? -> list?
 ;;   Render a chapter block containing section cards.
 (define (chapter-block chapter)
   (match chapter
@@ -2943,7 +2943,7 @@
                  ,@(map (λ (section) (section-card section implemented-set))
                         sections)))]))
 
-;; Contract: procedure? list? -> (or/c #f any/c)
+;; find-first: procedure? list? -> (or/c #f any/c)
 ;;   Return the first list element that satisfies pred.
 (define (find-first pred lst)
   (cond
@@ -2976,7 +2976,7 @@
         (list "Macros" "Syntax Object Content"
               "Macro expansion and syntax tooling depend on this set.")))
 
-;; Contract: -> list?
+;; attention-candidates: -> list?
 ;;   Build attention metadata entries that match known sections.
 (define (attention-candidates)
   (for/list ([entry (in-list attention-metadata)]
@@ -2998,14 +2998,14 @@
        (define anchor-id (list-ref stat 7))
        (list display title note implemented-count total missing pct-num anchor-id)])))
 
-;; Contract: list? exact-nonnegative-integer? -> list?
+;; take-up-to: list? exact-nonnegative-integer? -> list?
 ;;   Take up to n items from a list.
 (define (take-up-to lst n)
   (if (or (zero? n) (null? lst))
       '()
       (cons (car lst) (take-up-to (cdr lst) (sub1 n)))))
 
-;; Contract: -> list?
+;; needs-attention-items: -> list?
 ;;   Select top attention items with low completion.
 (define (needs-attention-items)
   (define filtered
@@ -3027,7 +3027,7 @@
               [else (> missing-a missing-b)]))))
   (take-up-to sorted 4))
 
-;; Contract: list? -> list?
+;; attention-card: list? -> list?
 ;;   Render an attention card summary for a section.
 (define (attention-card item)
   (define display (list-ref item 0))
@@ -3052,7 +3052,7 @@
                (aria-label ,(string-append "View missing for " label)))
             "View missing")))
 
-;; Contract: -> list?
+;; status-legend: -> list?
 ;;   Render the legend explaining status chips.
 (define (status-legend)
   `(div (@ (class "status-legend"))
@@ -3066,7 +3066,7 @@
                 " not yet implemented in the runtime.")
             (li "Pict is tracked separately."))))
 
-;; Contract: -> list?
+;; status-insight-callout: -> list?
 ;;   Render a callout highlighting strongest and weakest sections.
 (define (status-insight-callout)
   (define strong-candidates
@@ -3103,7 +3103,7 @@
                 weak-title weak-pct weak-implemented weak-total)
        " these gaps will unlock more programs.")))
 
-;; Contract: any/c -> list?
+;; node-list->list: any/c -> list?
 ;;   Convert a DOM NodeList into a Racket list.
 (define (node-list->list node-list)
   (define len (js-ref node-list "length"))
@@ -3117,20 +3117,20 @@
 
 (define status-handler-store '())
 
-;; Contract: procedure? -> void?
+;; remember-status-handler!: procedure? -> void?
 ;;   Store event handlers so they stay reachable.
 (define (remember-status-handler! handler)
   (set! status-handler-store (cons handler status-handler-store))
   (void))
 
-;; Contract: any/c string? -> boolean?
+;; classlist-contains?: any/c string? -> boolean?
 ;;   Check whether an element's classList contains a class.
 (define (classlist-contains? element class-name)
   (define selector (string-append "." class-name))
   (define result (and element (js-matches element selector)))
   (and (number? result) (not (zero? result))))
 
-;; Contract: any/c -> string?
+;; element-text: any/c -> string?
 ;;   Extract trimmed textContent from an element.
 (define (element-text element)
   (define content (and element (js-ref element "textContent")))
@@ -3138,7 +3138,7 @@
       (string-trim content)
       ""))
 
-;; Contract: string? -> void?
+;; status-open-target!: string? -> void?
 ;;   Expand and scroll to a status section by id.
 (define (status-open-target! target-id)
   (define section (js-get-element-by-id target-id))
@@ -3152,7 +3152,7 @@
       (js-send summary "focus"
                (vector (js-object (vector (vector "preventScroll" #t))))))))
 
-;; Contract: -> void?
+;; init-status-smooth-scroll!: -> void?
 ;;   Wire smooth scrolling for attention card links.
 (define (init-status-smooth-scroll!)
   (define links (node-list->list (js-query-selector-all "[data-attention-target]")))
@@ -3174,7 +3174,7 @@
     (status-open-target! (substring hash 1)))
   (void))
 
-;; Contract: any/c -> string?
+;; status-row-status: any/c -> string?
 ;;   Derive the status label from a primitive row element.
 (define (status-row-status row)
   (cond
@@ -3182,7 +3182,7 @@
     [(and row (classlist-contains? row "prim-row--stdlib")) "stdlib"]
     [else "missing"]))
 
-;; Contract: any/c any/c -> string?
+;; status-row-name: any/c any/c -> string?
 ;;   Resolve the display name for a row for sorting.
 (define (status-row-name row item)
   (define name-node (and row (js-element-query-selector row ".prim-name")))
@@ -3191,7 +3191,7 @@
       (element-text (or row item))
       name))
 
-;; Contract: string? -> (listof string?)
+;; status-group-order: string? -> (listof string?)
 ;;   Return status precedence ordering for a group filter.
 (define (status-group-order group)
   (cond
@@ -3199,7 +3199,7 @@
     [(string=? group "missing") (list "missing" "implemented" "stdlib")]
     [else (list "implemented" "stdlib" "missing")]))
 
-;; Contract: string? (listof string?) -> exact-nonnegative-integer?
+;; status-order-index: string? (listof string?) -> exact-nonnegative-integer?
 ;;   Find the index of a status in an ordering list.
 (define (status-order-index status order)
   (let loop ([rest order]
@@ -3209,7 +3209,7 @@
       [(string=? status (car rest)) idx]
       [else (loop (cdr rest) (add1 idx))])))
 
-;; Contract: any/c string? string? -> void?
+;; status-sort-list!: any/c string? string? -> void?
 ;;   Sort a status list in place by group and name.
 (define (status-sort-list! list-el active-group active-dir)
   (define items
@@ -3222,7 +3222,7 @@
       (define status (status-row-status row))
       (define name (status-row-name row item))
       (list item index status name)))
-  ;; Contract: list? list? -> boolean?
+  ;; item<?: list? list? -> boolean?
   ;;   Compare two decorated rows for sorting order.
   (define (item<? a b)
     (define status-a (list-ref a 2))
@@ -3244,7 +3244,7 @@
     (js-append-child! list-el (list-ref entry 0)))
   (void))
 
-;; Contract: list? string? -> void?
+;; status-sync-buttons!: list? string? -> void?
 ;;   Sync filter button states to active group.
 (define (status-sync-buttons! buttons active-group)
   (for ([button (in-list buttons)])
@@ -3256,7 +3256,7 @@
       (js-send class-list "toggle"
                (vector "status-chip--active" (and is-active #t))))))
 
-;; Contract: -> void?
+;; init-status-filter!: -> void?
 ;;   Initialize filter buttons and sorting per section.
 (define (init-status-filter!)
   (define sections (node-list->list (js-query-selector-all ".status-section")))
@@ -3267,7 +3267,7 @@
     (when (and list-el (pair? button-list))
       (define active-group "implemented")
       (define active-dir "asc")
-      ;; Contract: -> void?
+      ;; sync-and-sort!: -> void?
       ;;   Refresh button state and re-sort the list.
       (define (sync-and-sort!)
         (status-sync-buttons! button-list active-group)
@@ -3290,7 +3290,7 @@
       (sync-and-sort!)))
   (void))
 
-;; Contract: -> void?
+;; init-status-collapse-buttons!: -> void?
 ;;   Attach handlers to collapse expanded sections.
 (define (init-status-collapse-buttons!)
   (define buttons (node-list->list (js-query-selector-all ".status-body-hint")))
@@ -3306,7 +3306,7 @@
     (js-add-event-listener! button "click" handler))
   (void))
 
-;; Contract: -> void?
+;; init-status-page-handlers!: -> void?
 ;;   Initialize all behavior for the status page.
 (define (init-status-page-handlers!)
   (init-status-smooth-scroll!)
@@ -3314,7 +3314,7 @@
   (init-status-collapse-buttons!)
   (void))
 
-;; Contract: -> list?
+;; implementation-status-page: -> list?
 ;;   Render the implementation status dashboard page.
 (define (implementation-status-page)
   `(div (@ (class "page page--status"))


### PR DESCRIPTION
### Motivation

- Improve consistency and clarity of contract annotations by using the actual function name as the comment prefix instead of the generic `Contract:` label.
- Make it easier to scan and associate contracts with their definitions, including nested helpers.

### Description

- Replaced comment headers of the form `;; Contract: ...` with `;; <function-name>: ...` across `web-site/src/completion.rkt` so each contract comment begins with the corresponding function name (including local helper names like `insert`, `ascii-alnum?`, and `item<?`).
- Updated many top-level and nested comment lines to follow the `;; name: <contract>` convention without changing any code logic or behavior.
- This is a documentation-only change limited to `web-site/src/completion.rkt` (39 lines adjusted).

### Testing

- No runtime changes were made; this is a comments-only refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4b09a308832299c3fd29300a9379)