### PR TITLE
Add js-log calls to status page click handlers

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3187,6 +3187,7 @@
     (define handler
       (procedure->external
        (lambda (evt)
+         (js-log "status-smooth-scroll-click")
          (define target-id (js-get-attribute link "data-attention-target"))
          (when (and (string? target-id) (not (string=? target-id "")))
            (js-event-prevent-default evt)
@@ -3311,6 +3312,7 @@
         (define handler
           (procedure->external
            (lambda (_evt)
+             (js-log "status-filter-click")
              (define group (js-get-attribute button "data-status-group"))
              (when (and (string? group) (not (string=? group "")))
                (if (string=? group active-group)
@@ -3334,6 +3336,7 @@
     (define handler
       (procedure->external
        (lambda (_evt)
+         (js-log "status-collapse-click")
          (define details (js-send button "closest" (vector "details")))
          (when details
            (js-remove-attribute! details "open"))


### PR DESCRIPTION
### Motivation
- Make it easy to verify event handlers are wired correctly in the browser after porting JavaScript handlers to WebRacket.

### Description
- Insert `js-log` calls into the three status page click handlers (`status-smooth-scroll-click`, `status-filter-click`, `status-collapse-click`) in `web-site/src/completion.rkt` so the console shows an identifying message when each handler runs.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a980332d083229bdb6b9b94abf235)