### PR TITLE
Add debug logging for status filter clicks

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3314,6 +3314,12 @@
            (lambda (_evt)
              (js-log "status-filter-click")
              (define group (js-get-attribute button "data-status-group"))
+             (js-log (format "status-filter-debug: group=~a active-group=~a active-dir=~a list-items=~a"
+                             group
+                             active-group
+                             active-dir
+                             (length (node-list->list
+                                      (js-element-query-selector-all list-el "li")))))
              (when (and (string? group) (not (string=? group "")))
                (if (string=? group active-group)
                    (set! active-dir (if (string=? active-dir "asc") "desc" "asc"))


### PR DESCRIPTION
### Motivation
- The filter click handler on the status page was not providing enough information to diagnose why the filter action wasn't taking effect, so extra runtime details are needed when the handler runs.

### Description
- Add a debug `js-log` call to the status filter click handler that logs the clicked `data-status-group`, the current `active-group`, `active-dir`, and the number of items in the list; change made in `web-site/src/completion.rkt`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a9b6c7df48322a010c15f5162b283)