### PR TITLE
Normalize status filter group attributes

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3275,12 +3275,21 @@
   (for ([entry (in-list (sort decorated item<?))])
     (js-append-child! list-el (list-ref entry 0))))
 
+;; status-group->string: any/c -> (or/c string? #f)
+;;   Normalize DOM attribute values to a string (or #f).
+;;   Returns a string value for JS external strings.
+(define (status-group->string group)
+  (cond
+    [(external? group) (external-string->string group)]
+    [else group]))
+
 ;; status-sync-buttons!: list? string? -> void?
 ;;   Sync filter button states to active group.
 ;;   Returns (void) after updating button state.
 (define (status-sync-buttons! buttons active-group)
   (for ([button (in-list buttons)])
-    (define group      (js-get-attribute button "data-status-group"))
+    (define group      (status-group->string
+                        (js-get-attribute button "data-status-group")))
     (define is-active  (and (string? group) (string=? group active-group)))
     (js-set-attribute! button "aria-pressed" (if is-active "true" "false"))
     (define class-list (js-ref button "classList"))
@@ -3313,7 +3322,8 @@
           (procedure->external
            (lambda (_evt)
              (js-log "status-filter-click")
-             (define group (js-get-attribute button "data-status-group"))
+             (define group (status-group->string
+                            (js-get-attribute button "data-status-group")))
              (js-log (format "status-filter-debug: group=~a active-group=~a active-dir=~a list-items=~a"
                              group
                              active-group


### PR DESCRIPTION
### Motivation
- Ensure status filter button handling treats DOM attribute values consistently by normalizing potential JS external strings before comparison and logging.

### Description
- Add `status-group->string` to convert JS external attribute values to Racket strings using `external-string->string`.
- Use `status-group->string` when reading `data-status-group` in `status-sync-buttons!` and the filter button click handler so comparisons and log output use normalized string values.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a9db3df248322ac3c99c0c355074e)