### PR TITLE
Remove status page debug logging

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -2769,7 +2769,6 @@
              (for/list ([entry (in-list raw-sections)])
                (list (symbol->title (car entry)) (cdr entry)))
              implemented)])))
-; (js-log prepared-chapters)
 
 
 ;; format-percent: real? -> exact-integer?
@@ -3187,7 +3186,6 @@
     (define handler
       (procedure->external
        (lambda (evt)
-         (js-log "status-smooth-scroll-click")
          (define target-id (js-get-attribute link "data-attention-target"))
          (when (and (string? target-id) (not (string=? target-id "")))
            (js-event-prevent-default evt)
@@ -3321,15 +3319,8 @@
         (define handler
           (procedure->external
            (lambda (_evt)
-             (js-log "status-filter-click")
              (define group (status-group->string
                             (js-get-attribute button "data-status-group")))
-             (js-log (format "status-filter-debug: group=~a active-group=~a active-dir=~a list-items=~a"
-                             group
-                             active-group
-                             active-dir
-                             (length (node-list->list
-                                      (js-element-query-selector-all list-el "li")))))
              (when (and (string? group) (not (string=? group "")))
                (if (string=? group active-group)
                    (set! active-dir (if (string=? active-dir "asc") "desc" "asc"))
@@ -3352,7 +3343,6 @@
     (define handler
       (procedure->external
        (lambda (_evt)
-         (js-log "status-collapse-click")
          (define details (js-send button "closest" (vector "details")))
          (when details
            (js-remove-attribute! details "open"))


### PR DESCRIPTION
### Motivation
- Remove stray debug `js-log` calls from the status page handlers to reduce console noise now that the status filter click behavior is fixed.

### Description
- Deleted `js-log` calls from `init-status-smooth-scroll!`, `init-status-filter!`, and `init-status-collapse-buttons!` in `web-site/src/completion.rkt` and removed a commented debug line.

### Testing
- No automated tests were modified; this change only removes debug logging and does not alter functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa4166f448322a01aa1b3c0f7f6bf)