### PR TITLE
Fix unmatched parenthesis in status filter handlers

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3317,7 +3317,7 @@
         (js-add-event-listener! button "click" handler))
 
       (set-active-state! (active-group) (active-dir))
-      (sync-and-sort! (active-group) (active-dir)))))
+      (sync-and-sort! (active-group) (active-dir))))
 
 ;; init-status-collapse-buttons!: -> void?
 ;;   Attach handlers to collapse expanded sections.


### PR DESCRIPTION
### Motivation
- Resolve a read error caused by an extra closing parenthesis in `web-site/src/completion.rkt` that broke the `init-status-filter!` handler nesting and prevented the file from being read.

### Description
- Remove the stray closing parenthesis so the final call in `init-status-filter!` is `(sync-and-sort! (active-group) (active-dir))` and restore proper parenthesis balance in `web-site/src/completion.rkt`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aaf4f37b08322bd21d81921a53728)