### PR TITLE
Fix status filter local bindings

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3275,49 +3275,49 @@
                          (js-element-query-selector-all section "[data-status-group]")))
 
     (when (and list-el (pair? button-list))
-      (define (active-group)
-        (define current (status-group->string
-                         (js-get-attribute section "data-status-active-group")))
-        (if (string? current) current "implemented"))
+      (let* ([active-group
+              (lambda ()
+                (define current (status-group->string
+                                 (js-get-attribute section "data-status-active-group")))
+                (if (string? current) current "implemented"))]
+             [active-dir
+              (lambda ()
+                (define current (status-group->string
+                                 (js-get-attribute section "data-status-active-dir")))
+                (if (string? current) current "asc"))]
+             [set-active-state!
+              (lambda (group dir)
+                (js-set-attribute! section "data-status-active-group" group)
+                (js-set-attribute! section "data-status-active-dir" dir))]
+             ;; sync-and-sort!: -> void?
+             ;;   Refresh button state and re-sort the list.
+             ;;   Returns (void) after syncing state.
+             [sync-and-sort!
+              (lambda (group dir)
+                (status-sync-buttons! button-list group)
+                (status-sort-list! list-el group dir))])
+        (for ([button (in-list button-list)])
+          (define handler
+            (procedure->external
+             (lambda (_evt)
+               (define group (status-group->string
+                              (js-get-attribute button "data-status-group")))
+               (when (and (string? group) (not (string=? group "")))
+                 (define current-group (active-group))
+                 (define current-dir   (active-dir))
+                 (define next-dir
+                   (if (string=? group current-group)
+                       (if (string=? current-dir "asc") "desc" "asc")
+                       "asc"))
+                 (define next-group group)
+                 (set-active-state! next-group next-dir)
+                 (sync-and-sort! next-group next-dir)))))
 
-      (define (active-dir)
-        (define current (status-group->string
-                         (js-get-attribute section "data-status-active-dir")))
-        (if (string? current) current "asc"))
+          (remember-status-handler! handler)
+          (js-add-event-listener! button "click" handler)))
 
-      (define (set-active-state! group dir)
-        (js-set-attribute! section "data-status-active-group" group)
-        (js-set-attribute! section "data-status-active-dir" dir))
-
-      ;; sync-and-sort!: -> void?
-      ;;   Refresh button state and re-sort the list.
-      ;;   Returns (void) after syncing state.
-      (define (sync-and-sort! group dir)
-        (status-sync-buttons! button-list group)
-        (status-sort-list! list-el group dir))
-
-      (for ([button (in-list button-list)])
-        (define handler
-          (procedure->external
-           (lambda (_evt)
-             (define group (status-group->string
-                            (js-get-attribute button "data-status-group")))
-             (when (and (string? group) (not (string=? group "")))
-               (define current-group (active-group))
-               (define current-dir   (active-dir))
-               (define next-dir
-                 (if (string=? group current-group)
-                     (if (string=? current-dir "asc") "desc" "asc")
-                     "asc"))
-               (define next-group group)
-               (set-active-state! next-group next-dir)
-               (sync-and-sort! next-group next-dir)))))
-
-        (remember-status-handler! handler)
-        (js-add-event-listener! button "click" handler)))
-
-      (set-active-state! (active-group) (active-dir))
-      (sync-and-sort! (active-group) (active-dir))))
+        (set-active-state! (active-group) (active-dir))
+        (sync-and-sort! (active-group) (active-dir)))))
 
 ;; init-status-collapse-buttons!: -> void?
 ;;   Attach handlers to collapse expanded sections.


### PR DESCRIPTION
### Motivation
- Resolve a compilation/runtime error caused by unresolved local bindings when initializing the status filter (e.g. unknown global `$active-group`).
- Ensure the status filter helper functions are properly scoped per section to avoid accidental global references.

### Description
- Replace nested `define` helper functions inside `init-status-filter!` with `let*`-bound lambdas for `active-group`, `active-dir`, `set-active-state!`, and `sync-and-sort!`.
- Preserve existing button wiring and sorting logic while making the helper functions proper local values captured by the event handlers.
- Keep the external event handler wrapping (`procedure->external`) and handler registration (`remember-status-handler!` / `js-add-event-listener!`) unchanged.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ab0b57c2c8322b667c107e1919e5d)