### PR TITLE
Avoid values predicate in status grid reordering

### DIFF
--- a/web-site/src/completion.rkt
+++ b/web-site/src/completion.rkt
@@ -3217,7 +3217,7 @@
                             (quotient idx row-count)))
           (when (< target count)
             (vector-set! reordered target card)))
-        (filter values (vector->list reordered)))))
+        (filter (λ (item) item) (vector->list reordered)))))
 
 ;; status-grid-current-columns: any/c -> (or/c exact-positive-integer? #f)
 ;;   Read stored column count metadata for a status grid.


### PR DESCRIPTION
### Motivation
- The column-major reordering used `(filter values ...)` which relied on `values` as a predicate and could be misused by the toolchain, so replace it with an explicit predicate to avoid unsupported predicate usage.

### Description
- Replace `(filter values (vector->list reordered))` with `(filter (λ (item) item) (vector->list reordered))` in `web-site/src/completion.rkt` inside `status-grid-column-major` to drop placeholder `#f` slots and return a proper list of cards.

### Testing
- Small, single-line refactor with no semantic change; verified by code inspection and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ab7340c288322a5070848842fb47d)