### PR TITLE
Fix quick start step underline duplication

### DIFF
--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -1550,6 +1550,9 @@ pre {
 .page--quick-start .section--quick-start-step .section-title {
   font-weight: 650;
 }
+.page--quick-start .section--quick-start-step .qs-step-title::after {
+  content: none;
+}
 .page--quick-start .section--quick-start-step .qs-step-header {
   flex-direction: row;
   align-items: flex-start;


### PR DESCRIPTION
### Motivation
- Quick Start step headings were rendering two underline bars because the global `.section-title::after` rule and the new `.qs-step-underline` were both active for step headers.

### Description
- Scoped the global underline off for Quick Start step headings by adding `.page--quick-start .section--quick-start-step .qs-step-title::after { content: none; }` so the new `.qs-step-underline` remains the sole underline.

### Testing
- Attempted to build the site with `./web-site/src/build.sh` to validate the layout but the build failed because `racket` is not available in the environment, so visual verification could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b92dbc6f48322a9cc39732738b5af)