### PR TITLE
Fix MathJax page initialization order

### DIFF
--- a/web-site/src/examples/mathjax.rkt
+++ b/web-site/src/examples/mathjax.rkt
@@ -8,7 +8,7 @@
 (define mathjax-default-expression
   "\\int_{0}^{\\pi} \\sin(x)\\,dx = 2")
 
-(define mathjax-page-layout
+(define (mathjax-page)
   `(div (@ (class "page page--mathjax"))
         ,(navbar)
         (section (@ (class "mathjax-hero"))

--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -3010,7 +3010,7 @@ CSS
       [(quick-start)           (quick-start-page)]
       [(installation)          (installation-page)]
       [(community)             (community-page)]
-      [(mathjax)               mathjax-page-layout]
+      [(mathjax)               (mathjax-page)]
       [else                    (home-page)]))
   
   (define page (sxml->dom page-structure))


### PR DESCRIPTION
### Motivation
- The MathJax page layout evaluated `(navbar)` at module load time, causing an initialization-time call before `navbar` was available and crashing the site.

### Description
- Convert the page layout to a builder function by replacing `mathjax-page-layout` with `(define (mathjax-page) ...)` in `web-site/src/examples/mathjax.rkt` so `navbar` is invoked at render time.
- Update the page selector in `web-site/src/web-site.rkt` to call `(mathjax-page)` when the current page is `mathjax`.

### Testing
- Not applicable; this is a small initialization-order fix that updates `web-site/src/examples/mathjax.rkt` and `web-site/src/web-site.rkt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd6af0d1883228e3d5c9bc6448d58)