### PR TITLE
Allow local definitions in MathJax script initialization with `(let () ...)`

### DIFF
--- a/web-site/src/examples/mathjax.rkt
+++ b/web-site/src/examples/mathjax.rkt
@@ -110,13 +110,13 @@
 (define (load-mathjax-script!)
   (define existing (js-get-element-by-id "mathjax-script"))
   (if existing
-      (begin
+      (let ()
         (define mathjax (js-ref (js-var "window") "MathJax"))
         (when mathjax
           (set! mathjax-loaded? #t)
           (render-mathjax-preview))
         (js-add-event-listener! existing "load" mathjax-loaded-handler))
-      (begin
+      (let ()
         (define head   (js-document-head))
         (define script (js-create-element "script"))
         (js-set-attribute! script "id" "mathjax-script")


### PR DESCRIPTION
### Motivation
- Enable the use of internal `define` forms inside the branches of `load-mathjax-script!` without using `begin`, since `begin` does not support definitions and local `define`s must not be turned into plain `let` bindings.

### Description
- Wrap both the `existing` and non-`existing` branches of `load-mathjax-script!` in `(let () ...)` and move internal locals into those blocks (e.g. `mathjax`, `head`, `script`), preserving the original behavior of detecting `MathJax`, setting `mathjax-loaded?`, adding the `load` event listener, and appending the script element; also keep the `latex` binding in `render-mathjax-preview` as a local `define`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bdda0b308832289ae10c7ad5b2764)