### PR TITLE
Enhance MathJax live preview styling and copy

### DIFF
--- a/web-site/src/examples/mathjax.rkt
+++ b/web-site/src/examples/mathjax.rkt
@@ -28,7 +28,7 @@
                          "Type LaTeX on the left and watch the preview update instantly.")))
         ,(section-block
           "Live editor"
-          "Use standard LaTeX syntax to render math with MathJax 4."
+          "Write standard LaTeX and see MathJax 4 render it instantly."
           (list
            `(div (@ (class "mathjax-grid"))
                  (div (@ (class "mathjax-pane"))

--- a/web-site/src/web-site.rkt
+++ b/web-site/src/web-site.rkt
@@ -2900,16 +2900,29 @@ pre code {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 18px;
+  padding: 22px;
   text-align: center;
+  color: var(--text);
 }
 .mathjax-preview mjx-container {
-  font-size: 120%;
+  font-size: 150%;
+  margin: 0 auto;
+  max-width: 100%;
 }
 .mathjax-hint {
   margin: 0;
-  color: var(--muted);
-  font-size: 0.9rem;
+  color: rgba(182, 189, 221, 0.82);
+  font-size: 0.82rem;
+  font-style: italic;
+  line-height: 1.55;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px dashed rgba(74, 108, 255, 0.28);
+  background: rgba(74, 108, 255, 0.08);
+}
+.mathjax-hint code {
+  font-style: normal;
+  color: rgba(235, 238, 255, 0.95);
 }
 .mathjax-details {
   display: flex;


### PR DESCRIPTION
### Motivation

- Improve the visual treatment of the MathJax live preview so rendered math is larger and more centered, make the hint text read like a tool hint, and update the editor description to the requested phrasing.

### Description

- Update the Live editor description string in `web-site/src/examples/mathjax.rkt` to: `"Write standard LaTeX and see MathJax 4 render it instantly."`.
- Increase the visual size and centering of rendered math by adjusting `.mathjax-preview` and its child `mjx-container` in `web-site/src/web-site.rkt` (`padding: 22px;`, `mjx-container { font-size: 150%; margin: 0 auto; max-width: 100%; }`) and ensure foreground contrast with `color: var(--text)`.
- Restyle the hint text `.mathjax-hint` to feel like a subtle tool hint by reducing visual weight and size, adding `font-style: italic`, muted color, smaller `font-size`, subtle background, padding and dashed border, rounded corners, and ensure inline `code` inside the hint uses normal font-style and brighter color for readability.

### Testing

- Ran the project build script `./build.sh` under `web-site/src`; the script attempted to compile the site but the build could not complete because `racket` is not available in the environment, so a full site build and wasm artifact were not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bf54225488322b2c33590f7cb22a0)