### PR TITLE
Fix Formula 1 page retry button event listener callback type

### DIFF
--- a/web-site/src/examples/formula1-page.rkt
+++ b/web-site/src/examples/formula1-page.rkt
@@ -498,5 +498,5 @@
 (define (init-formula1-page!)
   (js-set! (js-var "document") "title" "Formula 1 next race")
   (define retry-button (js-get-element-by-id "f1-retry-button"))
-  (js-add-event-listener! retry-button "click" (lambda (_evt) (render-f1-countdown!)))
+  (js-add-event-listener! retry-button "click" (procedure->external (lambda (_evt) (render-f1-countdown!))))
   (render-f1-countdown!))


### PR DESCRIPTION
### Motivation
- Prevent a runtime trap caused by passing a plain Racket procedure to the FFI `js-add-event-listener!`, which expects an external (JS-compatible) callback.

### Description
- Wrap the retry button click handler with `procedure->external` before passing it to `js-add-event-listener!` in `web-site/src/examples/formula1-page.rkt` so the FFI receives an extern callback.

### Testing
- Attempted to run `raco make web-site/src/examples/formula1-page.rkt`, but `raco` is not available in this environment so compilation checks could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698886159f2483229d259592007b9025)