### PR TITLE
Simplify Formula 1 weekend titles in formula1-page

### DIFF
--- a/web-site/src/examples/formula1-page.rkt
+++ b/web-site/src/examples/formula1-page.rkt
@@ -77,6 +77,26 @@
                              (string-length " - Race")))]
     [else summary]))
 
+;; display-weekend-name : String -> String
+;; Converts ICS race summaries into a cleaner label for the UI card title.
+(define (display-weekend-name summary)
+  (define base (weekend-key summary))
+  (define no-f1
+    (if (string-prefix? base "F1 ")
+        (substring base 3)
+        base))
+  (define sponsor-prefixes
+    (list "Qatar Airways "
+          "Aramco "
+          "Lenovo "
+          "Pirelli "
+          "Aws "))
+  (for/fold ([clean no-f1])
+            ([prefix (in-list sponsor-prefixes)])
+    (if (string-prefix? clean prefix)
+        (substring clean (string-length prefix))
+        clean)))
+
 ;; parse-events : String -> (Listof f1-event)
 ;; Parse an ICS calendar string into a list of race events.
 (define (parse-events text)
@@ -400,7 +420,8 @@
       (let ()
         (define-values (sprint race) (find-weekend-events next-race))
         (define title
-          (string-append "Next race weekend: " (weekend-key (f1-event-summary race))))
+          (string-append "Next race weekend: "
+                         (display-weekend-name (f1-event-summary race))))
         (define-values (countdown-value countdown-unit countdown-label)
           (race-countdown-parts now race))
         (js-set! title-node "textContent" title)


### PR DESCRIPTION
### Motivation
- The ICS calendar summaries include extra prefixes (e.g. `F1 ` and sponsor names) that make the UI title verbose, so the page should display a cleaner weekend name like `Australian GP 2026`.

### Description
- Added `display-weekend-name` to `web-site/src/examples/formula1-page.rkt` to derive a cleaned label by removing an `F1 ` prefix and common sponsor prefixes such as `Qatar Airways `, `Aramco `, `Lenovo `, `Pirelli `, and `Aws `.
- Replaced the title construction for the countdown card to use `(display-weekend-name (f1-event-summary race))` instead of the raw weekend key.
- The change is confined to `web-site/src/examples/formula1-page.rkt` and preserves existing parsing and countdown logic.

### Testing
- Attempted to run the example with `racket -t web-site/src/examples/formula1-page.rkt` but `racket` is not installed in this environment, so that check could not run.
- Started a static server with `python3 -m http.server 4173 --directory web-site/src` and exercised the page via a Playwright script that navigated to `http://127.0.0.1:4173/formula1.html` and captured a screenshot, which completed successfully.
- The change was committed locally to the branch and the updated file diff shows the new helper and title update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889a13f3ac8322a1b8047f2413f0ee)