### PR TITLE
Fix matrix rain runtime crash in terminal color rendering

### DIFF
--- a/web-site/src/examples/matrix-rain-page.rkt
+++ b/web-site/src/examples/matrix-rain-page.rkt
@@ -200,7 +200,7 @@
       (define g (inexact->exact (round (+ 80. (* i 175.)))))
       (define r (inexact->exact (round (* i 40.))))
       (define b (inexact->exact (round (* i 70.))))
-      (values r g b))
+      (vector r g b))
 
     (define (render!)
       (define payload
@@ -216,7 +216,10 @@
                (define char  (vector-ref row-char col))
                (if (<= value 0.)
                    (write-char #\space out)
-                   (let-values ([(r g b) (intensity->rgb value)])
+                   (let* ([rgb (intensity->rgb value)]
+                          [r (vector-ref rgb 0)]
+                          [g (vector-ref rgb 1)]
+                          [b (vector-ref rgb 2)])
                      (fprintf out "\u001b[38;2;~a;~a;~am~a" r g b char))))
              (display "\u001b[0m" out)
              (when (< row (sub1 rows))


### PR DESCRIPTION
### Motivation

- Prevent a runtime trap observed while rendering the Matrix Rain example where RGB components were extracted as multiple values, causing an unreachable error in the browser runtime.
- Keep the same color computation and visual output while making the return value safe to consume from `render!`.

### Description

- Change `intensity->rgb` to return a single `vector` of three integers instead of returning multiple values (now `vector r g b`).
- Update `render!` to read `r`, `g`, and `b` from the returned vector using `vector-ref` before formatting the ANSI `38;2` color escape sequence.
- Modified file: `web-site/src/examples/matrix-rain-page.rkt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698930d3fe088322b5a7fab5565fbccf)